### PR TITLE
Fix-up vmstat call to use correct stats

### DIFF
--- a/plugins/system/vmstat-metrics.rb
+++ b/plugins/system/vmstat-metrics.rb
@@ -34,7 +34,7 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    result = convert_integers(`vmstat`.split("\n")[2].split(" "))
+    result = convert_integers(`vmstat 1 2|tail -n1`.split(" "))
     timestamp = Time.now.to_i
     metrics = {
       :procs => {


### PR DESCRIPTION
From the vmstat man page:

```
   The  first  report produced gives averages since the last reboot.  Additional reports give informa-
   tion on a sampling period of length delay.  The process and memory  reports  are  instantaneous  in
   either case.
```

So, when run with no arguments, vmstat produces figures that are averages since the last reboot - not entirely useful!

This small change ensures that vmstat runs twice, and the plugin parses the second line of output which will be the values measured over the previous second.
