### PR TITLE
Fixing IRC handler: +short_name+ takes no parameters.

### DIFF
--- a/handlers/notification/irc.rb
+++ b/handlers/notification/irc.rb
@@ -39,10 +39,10 @@ class IRC < Sensu::Handler
     begin
       timeout(10) do
         CarrierPigeon.send(params)
-        puts 'irc -- sent alert for ' + short_name(@event) + ' to IRC.'
+        puts 'irc -- sent alert for ' + short_name + ' to IRC.'
       end
     rescue Timeout::Error
-      puts 'irc -- timed out while attempting to ' + @event['action'] + ' a incident -- ' + short_name(@event)
+      puts 'irc -- timed out while attempting to ' + @event['action'] + ' a incident -- ' + short_name
     end
   end
 


### PR DESCRIPTION
Easy fix for IRC handler.  There may be some further issues contained in carrier-pigeon, but this should clean up the irc.rb handler itself.
