### PR TITLE
Fix to vmstat-metrics in order to see inactive/active memory vs buffers/cache

### DIFF
--- a/plugins/system/vmstat-metrics.rb
+++ b/plugins/system/vmstat-metrics.rb
@@ -34,7 +34,7 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    result = convert_integers(`vmstat 1 2|tail -n1`.split(" "))
+    result = convert_integers(`vmstat -a 1 2|tail -n1`.split(" "))
     timestamp = Time.now.to_i
     metrics = {
       :procs => {


### PR DESCRIPTION
# vmstat -a                                                                                                                                                                                    ~

procs -----------memory---------- ---swap-- -----io---- -system-- ----cpu----
 r  b   swpd   free  inact active   si   so    bi    bo   in   cs us sy id wa
 2  0 152388 229152 1187024 257972    0    2     1     1    0    1 47 22 27  1
# vmstat                                                                                                                                                                                             ~

procs -----------memory---------- ---swap-- -----io---- -system-- ----cpu----
 r  b   swpd   free   buff  cache   si   so    bi    bo   in   cs us sy id wa
 2  0 152388 226112  11092 1087072    0    2     1     1    0    1 47 22 27  1
