### PR TITLE
Adding initial Geckoboard handler.

### DIFF
--- a/handlers/metrics/geckoboard-push.json
+++ b/handlers/metrics/geckoboard-push.json
@@ -1,0 +1,17 @@
+{
+ "geckoboard": {
+    "checks": {
+      "my.newrelic.throughput": {
+        "type":"geckometer",
+        "min":"200",
+        "max":"40000",
+        "widget_key":"12322-a831fsdda99f0jajd0fjas0dfja0fju9"
+      },
+      "my.newrelic.responsetime": {
+        "type":"number_and_secondary_value",
+        "widget_key":"12322-df2f2fw29f9jf9sdfsf02ihf020s0dhf"
+      }
+    },
+    "api_key":"9239932fwew8f8777ff28fh8hf8dh"
+ }
+}

--- a/handlers/metrics/geckoboard-push.rb
+++ b/handlers/metrics/geckoboard-push.rb
@@ -1,0 +1,60 @@
+#!/usr/bin/env ruby
+#
+# Pushes metrics plugin output to geckoboard.
+# ===
+#
+# TODO: Add more options for output to geckoboard
+#
+# Copyright 2012 Pete Shima <me@peteshima.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-handler'
+require 'geckoboard-push'
+
+class GeckoboardPush < Sensu::Handler
+
+  # override filters from Sensu::Handler. not appropriate for metric handlers
+  def filter; end
+
+  def handle
+  Geckoboard::Push.api_key = settings["geckoboard"]["api_key"]
+
+    checks = settings["geckoboard"]["checks"]
+
+    metrics = @event['check']['output']
+
+    all = []
+
+    #probably a better way to do this than loop over the output twice
+    metrics.split(/\n/).each do |m|
+      v = m.split(/\t/)
+      all << {:value => v[1], :label => v[0]}
+    end
+
+    metrics.split(/\n/).each do |m|
+      v = m.split(/\t/)
+      if checks.has_key?(v[0])
+        c = settings["geckoboard"]["checks"][v[0]]
+        wk = c["widget_key"]
+        
+        case c["type"]
+        when "number_and_secondary_value"
+          Geckoboard::Push.new(wk).number_and_secondary_value(v[1], v[1])
+        when "geckometer"
+          Geckoboard::Push.new(wk).geckometer(v[1],c["min"],c["max"])
+        when "piechart"
+          Geckoboard::Push.new(wk).pie(all)
+        when "funnel"
+          Geckoboard::Push.new(wk).funnel(all)
+        end
+      end
+
+    end
+
+  end
+
+end


### PR DESCRIPTION
http://docs.geckoboard.com/api/push.html

Very handy if you want to get metrics out to geckoboard and you are already sending them to graphite.  If you are using the existing geckoboard new relic integration it works but there is no larger box option and this solves that issue.  Response time and throughput geckometers are pretty nice to have for non technical folks.
