### PR TITLE
moved metric category name into scheme defaults, removed from output

### DIFF
--- a/plugins/haproxy/haproxy-metrics.rb
+++ b/plugins/haproxy/haproxy-metrics.rb
@@ -51,7 +51,7 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}"
+    :default => "#{Socket.gethostname}.haproxy"
 
   def run
     uri = URI.parse(config[:connection])
@@ -76,11 +76,11 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
     parsed.shift
     parsed.each do |line|
       next if line[1] != 'BACKEND'
-      output "#{config[:scheme]}.haproxy.#{line[0]}.session_current", line[4]
-      output "#{config[:scheme]}.haproxy.#{line[0]}.session_total", line[7]
-      output "#{config[:scheme]}.haproxy.#{line[0]}.bytes_in", line[8]
-      output "#{config[:scheme]}.haproxy.#{line[0]}.bytes_out", line[9]
-      output "#{config[:scheme]}.haproxy.#{line[0]}.connection_errors", line[13]
+      output "#{config[:scheme]}.#{line[0]}.session_current", line[4]
+      output "#{config[:scheme]}.#{line[0]}.session_total", line[7]
+      output "#{config[:scheme]}.#{line[0]}.bytes_in", line[8]
+      output "#{config[:scheme]}.#{line[0]}.bytes_out", line[9]
+      output "#{config[:scheme]}.#{line[0]}.connection_errors", line[13]
     end
 
     ok

--- a/plugins/mysql/mysql-graphite.rb
+++ b/plugins/mysql/mysql-graphite.rb
@@ -51,7 +51,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}"
+    :default => "#{Socket.gethostname}.mysql"
 
   def run
 
@@ -190,7 +190,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
           if key == 'Seconds_Behind_Master' and value.nil?
             value = -1
           end
-          output "#{config[:scheme]}.mysql.general.#{general[key]}", value
+          output "#{config[:scheme]}.general.#{general[key]}", value
         end
       end
     rescue

--- a/plugins/newrelic/newrelic-metrics.rb
+++ b/plugins/newrelic/newrelic-metrics.rb
@@ -37,7 +37,7 @@ class NewRelicMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}"
+    :default => "#{Socket.gethostname}.newrelic"
 
   def run
     rpm = "http://rpm.newrelic.com"
@@ -55,7 +55,7 @@ class NewRelicMetrics < Sensu::Plugin::Metric::CLI::Graphite
     app = stats["accounts"].first["applications"].find {|v| v["name"] == config[:appname] }
     app["threshold_values"].each do |v|
       metric_name = v["name"].gsub(/\s+/, "_").downcase
-      output "#{config[:scheme]}.newrelic.#{metric_name}", v["metric_value"]
+      output "#{config[:scheme]}.#{metric_name}", v["metric_value"]
     end
 
     ok

--- a/plugins/nginx/nginx-metrics.rb
+++ b/plugins/nginx/nginx-metrics.rb
@@ -37,7 +37,7 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => Socket.gethostname
+    :default => "#{Socket.gethostname}.nginx"
 
   def run
     res = Net::HTTP.start(config[:hostname], config[:port]) do |http|
@@ -47,17 +47,17 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     res.body.split(/\r?\n/).each do |line|
       if connections = line.match(/^Active connections:\s+(\d+)/).to_a
-        output "#{config[:scheme]}.nginx.active_connections", connections[1]
+        output "#{config[:scheme]}.active_connections", connections[1]
       end
       if requests = line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/).to_a
-        output "#{config[:scheme]}.nginx.accepted", requests[1]
-        output "#{config[:scheme]}.nginx.handled", requests[2]
-        output "#{config[:scheme]}.nginx.handles", requests[3]
+        output "#{config[:scheme]}.accepted", requests[1]
+        output "#{config[:scheme]}.handled", requests[2]
+        output "#{config[:scheme]}.handles", requests[3]
       end
       if queue = line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/).to_a
-        output "#{config[:scheme]}.nginx.reading", queue[1]
-        output "#{config[:scheme]}.nginx.writing", queue[2]
-        output "#{config[:scheme]}.nginx.waiting", queue[3]
+        output "#{config[:scheme]}.reading", queue[1]
+        output "#{config[:scheme]}.writing", queue[2]
+        output "#{config[:scheme]}.waiting", queue[3]
       end
     end
 

--- a/plugins/processes/es-node-metrics.rb
+++ b/plugins/processes/es-node-metrics.rb
@@ -23,7 +23,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to queue_name.metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}"
+    :default => "#{Socket.gethostname}.elasticsearch"
 
   def run
     ln = RestClient::Resource.new 'http://localhost:9200/_cluster/nodes/_local', :timeout => 30
@@ -41,7 +41,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     metrics['jvm.mem.non_heap_used_in_bytes'] = node['jvm']['mem']['non_heap_used_in_bytes']
     metrics['jvm.gc.collection_time_in_millis'] = node['jvm']['gc']['collection_time_in_millis']
     metrics.each do |k,v|
-      output([config[:scheme], "elasticsearch", k].join("."), v, timestamp)
+      output([config[:scheme], k].join("."), v, timestamp)
     end
     ok
   end

--- a/plugins/resque/resque-metrics.rb
+++ b/plugins/resque/resque-metrics.rb
@@ -32,7 +32,7 @@ class ResqueMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => Socket.gethostname
+    :default => "#{Socket.gethostname}.resque"
 
   def run
 
@@ -43,15 +43,15 @@ class ResqueMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     Resque.queues.each do |v|
       sz = Resque.size(v)
-      output "#{config[:scheme]}.resque.queue.#{v}", sz
+      output "#{config[:scheme]}.queue.#{v}", sz
     end
 
-    output "#{config[:scheme]}.resque.queues", info[:queues]
-    output "#{config[:scheme]}.resque.workers", info[:workers]
-    output "#{config[:scheme]}.resque.working", info[:working]
-    output "#{config[:scheme]}.resque.failed", count
-    output "#{config[:scheme]}.resque.pending", info[:pending]
-    output "#{config[:scheme]}.resque.processed", info[:processed]
+    output "#{config[:scheme]}.queues", info[:queues]
+    output "#{config[:scheme]}.workers", info[:workers]
+    output "#{config[:scheme]}.working", info[:working]
+    output "#{config[:scheme]}.failed", count
+    output "#{config[:scheme]}.pending", info[:pending]
+    output "#{config[:scheme]}.processed", info[:processed]
 
     ok
   end

--- a/plugins/riak/riak-metrics.rb
+++ b/plugins/riak/riak-metrics.rb
@@ -38,7 +38,7 @@ class RiakMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}"
+    :default => "#{Socket.gethostname}.riak"
 
   def run
     res = Net::HTTP.start(config[:hostname], config[:port]) do |http|
@@ -139,7 +139,7 @@ class RiakMetrics < Sensu::Plugin::Metric::CLI::Graphite
     ]
 
     stats.reject {|k, v| exclude.include?(k) }.select {|k, v| stats[k].kind_of? Integer }.each do |k, v|
-      output "#{config[:scheme]}.riak.#{k}", v
+      output "#{config[:scheme]}.#{k}", v
     end
 
     ok

--- a/plugins/solr/solr-graphite.rb
+++ b/plugins/solr/solr-graphite.rb
@@ -61,66 +61,66 @@ class SolrGraphite < Sensu::Plugin::Metric::CLI::Graphite
     documentcache = stats["solr"]["solr_info"]["CACHE"]["entry"].find_all {|v| v["name"] == "documentCache"}.first["stats"]["stat"]
     filtercache = stats["solr"]["solr_info"]["CACHE"]["entry"].find_all {|v| v["name"] == "filterCache"}.first["stats"]["stat"]
 
-    output "#{config[:scheme]}.solr.core.maxdocs", core_searcher[2].strip!
-    output "#{config[:scheme]}.solr.core.maxdocs", core_searcher[3].strip!
-    output "#{config[:scheme]}.solr.core.warmuptime", core_searcher[9].strip!
+    output "#{config[:scheme]}.core.maxdocs", core_searcher[2].strip!
+    output "#{config[:scheme]}.core.maxdocs", core_searcher[3].strip!
+    output "#{config[:scheme]}.core.warmuptime", core_searcher[9].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.standard.requests", standard[1].strip!
-    output "#{config[:scheme]}.solr.queryhandler.standard.errors", standard[2].strip!
-    output "#{config[:scheme]}.solr.queryhandler.standard.timeouts", standard[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.standard.totaltime", standard[4].strip!
-    output "#{config[:scheme]}.solr.queryhandler.standard.timeperrequest", standard[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.standard.requestspersecond", standard[6].strip!
+    output "#{config[:scheme]}.queryhandler.standard.requests", standard[1].strip!
+    output "#{config[:scheme]}.queryhandler.standard.errors", standard[2].strip!
+    output "#{config[:scheme]}.queryhandler.standard.timeouts", standard[3].strip!
+    output "#{config[:scheme]}.queryhandler.standard.totaltime", standard[4].strip!
+    output "#{config[:scheme]}.queryhandler.standard.timeperrequest", standard[5].strip!
+    output "#{config[:scheme]}.queryhandler.standard.requestspersecond", standard[6].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.update.requests", update[1].strip!
-    output "#{config[:scheme]}.solr.queryhandler.update.errors", update[2].strip!
-    output "#{config[:scheme]}.solr.queryhandler.update.timeouts", update[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.update.totaltime", update[4].strip!
-    output "#{config[:scheme]}.solr.queryhandler.update.timeperrequest", update[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.update.requestspersecond", standard[6].strip!
+    output "#{config[:scheme]}.queryhandler.update.requests", update[1].strip!
+    output "#{config[:scheme]}.queryhandler.update.errors", update[2].strip!
+    output "#{config[:scheme]}.queryhandler.update.timeouts", update[3].strip!
+    output "#{config[:scheme]}.queryhandler.update.totaltime", update[4].strip!
+    output "#{config[:scheme]}.queryhandler.update.timeperrequest", update[5].strip!
+    output "#{config[:scheme]}.queryhandler.update.requestspersecond", standard[6].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.commits", updatehandler[0].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.autocommits", updatehandler[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.optimizes", updatehandler[4].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.rollbacks", updatehandler[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.docspending", updatehandler[7].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.adds", updatehandler[8].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.errors", updatehandler[11].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.cumulativeadds", updatehandler[12].strip!
-    output "#{config[:scheme]}.solr.queryhandler.updatehandler.cumulativeerrors", updatehandler[15].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.commits", updatehandler[0].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.autocommits", updatehandler[3].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.optimizes", updatehandler[4].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.rollbacks", updatehandler[5].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.docspending", updatehandler[7].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.adds", updatehandler[8].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.errors", updatehandler[11].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.cumulativeadds", updatehandler[12].strip!
+    output "#{config[:scheme]}.queryhandler.updatehandler.cumulativeerrors", updatehandler[15].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.querycache.lookups", querycache[0].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.hits", querycache[1].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.hitRatio", querycache[2].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.inserts", querycache[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.size", querycache[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.warmuptime", querycache[6].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.cumulativelookups", querycache[7].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.cumulativehits", querycache[8].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.cumulativehitratio", querycache[9].strip!
-    output "#{config[:scheme]}.solr.queryhandler.querycache.cumulativeinserts", querycache[10].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.lookups", querycache[0].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.hits", querycache[1].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.hitRatio", querycache[2].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.inserts", querycache[3].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.size", querycache[5].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.warmuptime", querycache[6].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.cumulativelookups", querycache[7].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.cumulativehits", querycache[8].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.cumulativehitratio", querycache[9].strip!
+    output "#{config[:scheme]}.queryhandler.querycache.cumulativeinserts", querycache[10].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.lookups", documentcache[0].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.hits", documentcache[1].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.hitRatio", documentcache[2].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.inserts", documentcache[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.size", documentcache[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.warmuptime", documentcache[6].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.cumulativelookups", documentcache[7].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.cumulativehits", documentcache[8].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.cumulativehitratio", documentcache[9].strip!
-    output "#{config[:scheme]}.solr.queryhandler.documentcache.cumulativeinserts", documentcache[10].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.lookups", documentcache[0].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.hits", documentcache[1].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.hitRatio", documentcache[2].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.inserts", documentcache[3].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.size", documentcache[5].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.warmuptime", documentcache[6].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.cumulativelookups", documentcache[7].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.cumulativehits", documentcache[8].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.cumulativehitratio", documentcache[9].strip!
+    output "#{config[:scheme]}.queryhandler.documentcache.cumulativeinserts", documentcache[10].strip!
 
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.lookups", filtercache[0].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.hits", filtercache[1].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.hitRatio", filtercache[2].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.inserts", filtercache[3].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.size", filtercache[5].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.warmuptime", filtercache[6].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.cumulativelookups", filtercache[7].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.cumulativehits", filtercache[8].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.cumulativehitratio", filtercache[9].strip!
-    output "#{config[:scheme]}.solr.queryhandler.filtercache.cumulativeinserts", documentcache[10].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.lookups", filtercache[0].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.hits", filtercache[1].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.hitRatio", filtercache[2].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.inserts", filtercache[3].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.size", filtercache[5].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.warmuptime", filtercache[6].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.cumulativelookups", filtercache[7].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.cumulativehits", filtercache[8].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.cumulativehitratio", filtercache[9].strip!
+    output "#{config[:scheme]}.queryhandler.filtercache.cumulativeinserts", documentcache[10].strip!
 
     ok
   end

--- a/plugins/youtube/youtube-metrics.rb
+++ b/plugins/youtube/youtube-metrics.rb
@@ -27,7 +27,7 @@ class YoutubeMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Metric naming scheme, text to prepend to metric",
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
-    :default => Socket.gethostname
+    :default => "#{Socket.gethostname}.youtube"
 
   def run
       unless config[:videoid].nil?
@@ -57,13 +57,13 @@ class YoutubeMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
         name = author.gsub(/(\W)/, '_').downcase
 
-        output "#{config[:scheme]}.youtube.video.#{config[:videoid]}.comments", comments
-        output "#{config[:scheme]}.youtube.video.#{config[:videoid]}.likes", likes
-        output "#{config[:scheme]}.youtube.video.#{config[:videoid]}.favorites", favorites
-        output "#{config[:scheme]}.youtube.video.#{config[:videoid]}.views", views
-        output "#{config[:scheme]}.youtube.channel.#{name}.subs", chansubs
-        output "#{config[:scheme]}.youtube.channel.#{name}.views", chanviews
-        output "#{config[:scheme]}.youtube.channel.#{name}.videoviews", chanuploadviews
+        output "#{config[:scheme]}.video.#{config[:videoid]}.comments", comments
+        output "#{config[:scheme]}.video.#{config[:videoid]}.likes", likes
+        output "#{config[:scheme]}.video.#{config[:videoid]}.favorites", favorites
+        output "#{config[:scheme]}.video.#{config[:videoid]}.views", views
+        output "#{config[:scheme]}.channel.#{name}.subs", chansubs
+        output "#{config[:scheme]}.channel.#{name}.views", chanviews
+        output "#{config[:scheme]}.channel.#{name}.videoviews", chanuploadviews
       end
 
     ok


### PR DESCRIPTION
Currently some plugins set the metric category name (mysql, solr, memcached etc) scheme default, and the others set it in the output string.

This PR moves it out of the output string and into to the scheme default across the board, which gives users the most flexibility when setting up their scheme name.
