### PR TITLE
added rabbitmq-overview-metrics.rb

### DIFF
--- a/plugins/rabbitmq/rabbitmq-overview-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-overview-metrics.rb
@@ -1,0 +1,116 @@
+#!/usr/bin/env ruby
+#
+# RabbitMQ Overview Metrics
+# ===
+#
+# Dependencies
+# -----------
+# - RabbitMQ `rabbitmq_management` plugin
+# - Ruby gem `carrot-top`
+#
+# Overview stats
+# ---------------
+# RabbitMQ 'overview' stats are similar to what is shown on the main page
+# of the rabbitmq_management web UI. Example:
+#
+#   $ rabbitmq-queue-metrics.rb
+#    host.rabbitmq.queue_totals.messages.count 0 1344186404
+#    host.rabbitmq.queue_totals.messages.rate  0.0 1344186404
+#    host.rabbitmq.queue_totals.messages_unacknowledged.count  0 1344186404
+#    host.rabbitmq.queue_totals.messages_unacknowledged.rate 0.0 1344186404
+#    host.rabbitmq.queue_totals.messages_ready.count 0 1344186404
+#    host.rabbitmq.queue_totals.messages_ready.rate  0.0 1344186404
+#    host.rabbitmq.message_stats.publish.count 4605755 1344186404
+#    host.rabbitmq.message_stats.publish.rate  17.4130186829638  1344186404
+#    host.rabbitmq.message_stats.deliver_no_ack.count  6661111 1344186404
+#    host.rabbitmq.message_stats.deliver_no_ack.rate 24.6867565643405  1344186404
+#    host.rabbitmq.message_stats.deliver_get.count 6661111 1344186404
+#    host.rabbitmq.message_stats.deliver_get.rate  24.6867565643405  1344186404#
+#
+# Copyright 2012 Joe Miller - https://github.com/joemiller
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/metric/cli'
+require 'socket'
+require 'carrot-top'
+
+
+class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
+
+  option :host,
+    :description => "RabbitMQ management API host",
+    :long => "--host HOST",
+    :default => "localhost"
+
+  option :port,
+    :description => "RabbitMQ management API port",
+    :long => "--port PORT",
+    :proc => proc {|p| p.to_i},
+    :default => 55672
+
+  option :user,
+    :description => "RabbitMQ management API user",
+    :long => "--user USER",
+    :default => "guest"
+
+  option :password,
+    :description => "RabbitMQ management API password",
+    :long => "--password PASSWORD",
+    :default => "guest"
+
+  option :scheme,
+    :description => "Metric naming scheme, text to prepend to $queue_name.$metric",
+    :long => "--scheme SCHEME",
+    :default => "#{Socket.gethostname}.rabbitmq"
+
+  def get_rabbitmq_info
+    begin
+      rabbitmq_info = CarrotTop.new(
+        :host => config[:host],
+        :port => config[:port],
+        :user => config[:user],
+        :password => config[:password]
+      )
+    rescue
+      warning "could not get rabbitmq info"
+    end
+    rabbitmq_info
+  end
+
+  def run
+    timestamp = Time.now.to_i
+
+    rabbitmq = get_rabbitmq_info
+    overview = rabbitmq.overview
+
+    # overview['queue_totals']['messages']
+    output "#{config[:scheme]}.queue_totals.messages.count", overview['queue_totals']['messages'], timestamp
+    output "#{config[:scheme]}.queue_totals.messages.rate", overview['queue_totals']['messages_details']['rate'], timestamp
+
+    # overview['queue_totals']['messages_unacknowledged']
+    output "#{config[:scheme]}.queue_totals.messages_unacknowledged.count", overview['queue_totals']['messages_unacknowledged'], timestamp
+    output "#{config[:scheme]}.queue_totals.messages_unacknowledged.rate", overview['queue_totals']['messages_unacknowledged_details']['rate'], timestamp
+
+    # overview['queue_totals']['messages_ready']
+    output "#{config[:scheme]}.queue_totals.messages_ready.count", overview['queue_totals']['messages_ready'], timestamp
+    output "#{config[:scheme]}.queue_totals.messages_ready.rate", overview['queue_totals']['messages_ready_details']['rate'], timestamp
+
+    # overview['message_stats']['publish']
+    output "#{config[:scheme]}.message_stats.publish.count", overview['message_stats']['publish'], timestamp
+    output "#{config[:scheme]}.message_stats.publish.rate", overview['message_stats']['publish_details']['rate'], timestamp
+
+    # overview['message_stats']['deliver_no_ack']
+    output "#{config[:scheme]}.message_stats.deliver_no_ack.count", overview['message_stats']['deliver_no_ack'], timestamp
+    output "#{config[:scheme]}.message_stats.deliver_no_ack.rate", overview['message_stats']['deliver_no_ack_details']['rate'], timestamp
+
+    # overview['message_stats']['deliver_get']
+    output "#{config[:scheme]}.message_stats.deliver_get.count", overview['message_stats']['deliver_get'], timestamp
+    output "#{config[:scheme]}.message_stats.deliver_get.rate", overview['message_stats']['deliver_get_details']['rate'], timestamp
+
+    ok
+  end
+
+end


### PR DESCRIPTION
similar to the `rabbitmq-queue-metrics.rb` plugin, but this one displays rabbit 'overview' or 'rollup' metrics instead of individual queue metrics.  see comment at top for example output.
