### PR TITLE
Postgres replication lag

### DIFF
--- a/plugins/postgres/postgres-graphite.rb
+++ b/plugins/postgres/postgres-graphite.rb
@@ -14,7 +14,6 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
   :default => "#{Socket.gethostname}.postgresql_replication_lag"
 
   def run
-    begin
     # Establishing connections to the master
     conn_master = PGconn.connect('@dbmaster',@dbport,'','','postgres',"@dbusername","@password")
     res1 = conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0,0)
@@ -40,7 +39,6 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Metric::CLI::Graphite
 
     output "#{config[:scheme]}", lag
 
-    end
     ok
   end
 end

--- a/plugins/postgres/postgres-replication-status.rb
+++ b/plugins/postgres/postgres-replication-status.rb
@@ -22,7 +22,6 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Check::CLI
 
 
   def run
-    begin
     # Establishing connections to the master
     conn_master = PGconn.connect('@dbmaster',@dbport,'','','postgres',"@dbusername","@password")
     res1 = conn_master.exec('SELECT pg_current_xlog_location()').getvalue(0,0)
@@ -55,6 +54,5 @@ class CheckpostgresReplicationStatus < Sensu::Plugin::Check::CLI
       ok "slave: #{message}"
     end
 
-    end
   end
 end


### PR DESCRIPTION
This pull request provides two plugins: 
One which allow us to monitor the postgresql replication lag. 
The other one allows those to be graphed in graphite.
