### PR TITLE
Allow setting custom header in check-http.rb

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -23,6 +23,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   option :host, :short => '-h HOST'
   option :path, :short => '-p PATH'
   option :port, :short => '-P PORT', :proc => proc { |a| a.to_i }
+  option :header, :short => '-H HEADER', :long => '--header HEADER'
   option :ssl, :short => '-s', :boolean => true, :default => false
   option :insecure, :short => '-k', :boolean => true, :default => false
   option :user, :short => '-U', :long => '--username USER'
@@ -79,6 +80,10 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
     req = Net::HTTP::Get.new(config[:path])
     if (config[:user] != nil and config[:password] != nil)
       req.basic_auth config[:user], config[:password]
+    end
+    if config[:header]
+      header, value = config[:header].split(':', 2)
+      req[header] = value.strip
     end
     res = http.request(req)
 


### PR DESCRIPTION
This patch adds an option to `check-http.rb` for setting a custom HTTP header using `--header` or `-H` (these argument names come from curl). 

Here at Paperless Post, we want to use this option to make a request to a specific nginx server on localhost that is listening on 'm.example.com', rather than the server listening on 'example.com', also on localhost. It's the equivalent of `curl localhost -H 'Host: m.example.com'`.

With this implementation it's only possible to add one header. I would like to make this work like curl where you can specify `-H` multiple times but I don't think mixlib-cli supports this.
