### PR TITLE
added the ability to specific a solr core for solr-graphite metric plugin

### DIFF
--- a/plugins/solr/solr-graphite.rb
+++ b/plugins/solr/solr-graphite.rb
@@ -45,6 +45,7 @@ class SolrGraphite < Sensu::Plugin::Metric::CLI::Graphite
     :default => "#{Socket.gethostname}.solr"
 
   def run
+    core = ""
     if config[:core]
         core = "/#{config[:core]}"
     end


### PR DESCRIPTION
This adds the ability to specify a Solr core to check by adding a new option: `--core`

Example:

```
    "solr_metrics": {
      "type": "metric",
      "handler": "graphite",
      "command": "/etc/sensu/plugins/solr-graphite.rb --host localhost --port 8983 --core local",
      "interval": 60,
      "subscribers": [ "default" ]
    },
```
