### PR TITLE
Fixing the mailer handler

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -23,11 +23,11 @@ class Mailer < Sensu::Handler
    @event['action'].eql?('resolve') ? "RESOLVED" : "ALERT"
   end
 
-  smtp_address = settings['mailer']['smtp_address'] || 'localhost'
-  smtp_port = settings['mailer']['smtp_port'] || '25'
-  smtp_domain = settings['mailer']['smtp_domain'] || 'localhost.localdomain'
-
   def handle
+    smtp_address = settings['mailer']['smtp_address'] || 'localhost'
+    smtp_port = settings['mailer']['smtp_port'] || '25'
+    smtp_domain = settings['mailer']['smtp_domain'] || 'localhost.localdomain'
+    
     params = {
       :mail_to   => settings['mailer']['mail_to'],
       :mail_from => settings['mailer']['mail_from'],


### PR DESCRIPTION
Movings the settings accessors to inside the handle block as they will fail if they are outside.
