### PR TITLE
typo in plugins/system/disk-capacity-metrics.rb inodes section

### DIFF
--- a/plugins/system/disk-capacity-metrics.rb
+++ b/plugins/system/disk-capacity-metrics.rb
@@ -76,7 +76,7 @@ class DiskCapacity < Sensu::Plugin::Metric::CLI::Graphite
               :disk=> {
                   "#{fs}.iused" => used,
                   "#{fs}.iavail" => avail,
-                  "#{fs}.capacity" => capacity.gsub('%','')
+                  "#{fs}.icapacity" => capacity.gsub('%','')
               }
           }
           metrics.each do |parent, children|


### PR DESCRIPTION
there was a typo where metrics would never be written to #{fs}.icapacity
