### PR TITLE
graphite path in memcached-graphite.rb says redis when it should say memcached.

### DIFF
--- a/plugins/memcached/memcached-graphite.rb
+++ b/plugins/memcached/memcached-graphite.rb
@@ -39,7 +39,7 @@ class MemcachedGraphite < Sensu::Plugin::Metric::CLI::Graphite
          :description => "Metric naming scheme, text to prepend to metric",
          :short       => "-s SCHEME",
          :long        => "--scheme SCHEME",
-         :default     => "#{::Socket.gethostname}.redis"
+         :default     => "#{::Socket.gethostname}.memcached"
 
   def run
     cache = Memcached.new("#{config[:host]}:#{config[:port]}")


### PR DESCRIPTION
The graphite path in memcached-graphite.rb says redis when it should say memcached.
