### PR TITLE
Change the regular expression in service match check

### DIFF
--- a/plugins/haproxy/check-haproxy.rb
+++ b/plugins/haproxy/check-haproxy.rb
@@ -65,7 +65,7 @@ class CheckHAProxy < Sensu::Plugin::Check::CLI
       haproxy.stats
     else
       haproxy.stats.select do |svc|
-        svc[:pxname] =~ /#{config[:service]}/
+        svc[:pxname] =~ /^#{config[:service]}$/
       end.reject do |svc|
         ["FRONTEND", "BACKEND"].include?(svc[:svname])
       end


### PR DESCRIPTION
This was necessary to do as previously if you have 2 services running named like this:

application
ssl_application

then if run with -s application, it would be matching application AND ssl_application which is not correct.
