### PR TITLE
New sensu check plugin: check-fs-writable

### DIFF
--- a/plugins/system/check-fs-writable.rb
+++ b/plugins/system/check-fs-writable.rb
@@ -18,15 +18,16 @@ class CheckFSWritable < Sensu::Plugin::Check::CLI
 
   def run
     unknown 'No directory specified' unless config[:dir]
-        critical "#{config[:dir]} does not exist " if !File.directory?(config[:dir])
+    critical "#{config[:dir]} does not exist " if !File.directory?(config[:dir])
     file = Tempfile.new('.sensu', config[:dir])
     begin
-        file.write("mops") or critical 'Could not write to filesystem'
-        file.read or critical 'Could not read from filesystem'
-   ensure
-        file.close 
-        file.unlink 
+      file.write("mops") or critical 'Could not write to filesystem'
+      file.read or critical 'Could not read from filesystem'
+    ensure
+      file.close 
+      file.unlink 
     end
-        ok "#{config[:dir]} is OK"      
+    ok "#{config[:dir]} is OK"      
   end
+
 end


### PR DESCRIPTION
check-fs-writable is a simple check that takes a directory as an
option and attempts to write a file to it. Returns critical if
the directory does not exist or if the temp file cannot be written
to it.
