### PR TITLE
cpu and ram checks

### DIFF
--- a/plugins/system/check-cpu.rb
+++ b/plugins/system/check-cpu.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+#
+# Check CPU Plugin
+# 
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+
+class CheckCPU < Sensu::Plugin::Check::CLI
+
+  option :warn,
+    :short => '-w WARN',
+    :proc => proc {|a| a.to_f },
+    :default => 80
+
+  option :crit,
+    :short => '-c CRIT',
+    :proc => proc {|a| a.to_f },
+    :default => 10
+
+  option :sleep,
+    :long => '--sleep SLEEP',
+    :proc => proc {|a| a.to_f },
+    :default => 1
+
+  [ :user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest ].each do |metric|
+    option metric,
+      :long  => "--#{metric}",
+      :description => "Check cpu #{metric} instead of total cpu usage",
+      :boolean => true,
+      :default => false
+  end
+
+  def get_cpu_stats
+    File.open("/proc/stat", "r").each_line do |line|
+      info = line.split(/\s+/)
+      name = info.shift
+      return info.map{|i| i.to_f} if name.match(/^cpu$/)
+    end
+  end
+
+  def run
+    metrics = [ :user, :nice, :system, :idle, :iowait, :irq, :softirq, :steal, :guest ]
+
+    cpu_stats_before = get_cpu_stats
+    sleep config[:sleep]
+    cpu_stats_after = get_cpu_stats
+
+    cpu_total_diff = 0.to_f
+    cpu_stats_diff = Array.new
+    metrics.each_index do |i|
+      cpu_stats_diff[i] = cpu_stats_after[i] - cpu_stats_before[i]
+      cpu_total_diff += cpu_stats_diff[i]
+    end
+
+    cpu_stats = Array.new
+    metrics.each_index do |i|
+      cpu_stats[i] = 100*(cpu_stats_diff[i]/cpu_total_diff)
+    end
+
+    cpu_usage = 100*(cpu_total_diff - cpu_stats_diff[3])/cpu_total_diff
+    checked_usage = cpu_usage
+
+    self.class.check_name 'CheckCPU TOTAL'
+    metrics.each do |metric|
+      if config[metric]
+        self.class.check_name "CheckCPU #{metric.to_s.upcase}"
+        checked_usage = cpu_stats[metrics.find_index(metric)]
+      end
+    end
+
+    msg = "total=#{cpu_usage.round(2)}"
+    cpu_stats.each_index {|i| msg += " #{metrics[i]}=#{cpu_stats[i].round(2)}"}
+
+    message msg
+
+    critical if checked_usage > config[:crit]
+    warning if checked_usage > config[:warn]
+    ok
+  end
+
+end

--- a/plugins/system/check-ram.rb
+++ b/plugins/system/check-ram.rb
@@ -1,0 +1,53 @@
+#!/usr/bin/env ruby
+#
+# Check RAM Plugin
+# 
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+
+class CheckRAM < Sensu::Plugin::Check::CLI
+
+  option :megabytes,
+    :short  => '-m',
+    :long  => '--megabytes',
+    :description => 'Unless --megabytes is specified the thresholds are in percents',
+    :boolean => true,
+    :default => false
+
+  option :warn,
+    :short => '-w WARN',
+    :proc => proc {|a| a.to_i },
+    :default => 10
+
+  option :crit,
+    :short => '-c CRIT',
+    :proc => proc {|a| a.to_i },
+    :default => 5
+
+  def run
+    total_ram, free_ram = 0, 0
+
+    `free -m`.split("\n").drop(1).each do |line|
+      free_ram = line.split[3].to_i if line =~ /^-\/\+ buffers\/cache:/
+      total_ram = line.split[1].to_i if line =~ /^Mem:/
+    end
+
+    if config[:megabytes]
+      message "#{free_ram} megabytes free RAM left"
+
+      critical if free_ram < config[:crit]
+      warning if free_ram < config[:warn]
+      ok
+    else
+      unknown "invalid percentage" if config[:crit] > 100 or config[:warn] > 100
+
+      percents_left = free_ram*100/total_ram
+      message "#{percents_left}% free RAM left"
+
+      critical if percents_left < config[:crit]
+      warning if percents_left < config[:warn]
+      ok
+    end
+  end
+end


### PR DESCRIPTION
check-cpu.rb can be used to alert on any of the cpu metrics available in /proc/stats or by default on total used cpu percentage. For ex this ceck can be used to check high iowait or steal time or idle time (in case you want to see if system is not too much idle which can identify a problem)
sleep is time to sleep between the two samples of /proc/stats

Usage: /etc/sensu/plugins/check-cpu.rb (options)
    -c CRIT
        --guest                      Check cpu guest instead of total cpu usage
        --idle                       Check cpu idle instead of total cpu usage
        --iowait                     Check cpu iowait instead of total cpu usage
        --irq                        Check cpu irq instead of total cpu usage
        --nice                       Check cpu nice instead of total cpu usage
        --sleep SLEEP
        --softirq                    Check cpu softirq instead of total cpu usage
        --steal                      Check cpu steal instead of total cpu usage
        --system                     Check cpu system instead of total cpu usage
        --user                       Check cpu user instead of total cpu usage
    -w WARN

check-ram.rb is to check hiow much free ram is left in megabytes or in percentage of total available ram

Usage: /etc/sensu/plugins/check-ram.rb (options)
    -c CRIT
    -m, --megabytes                  Unless --megabytes is specified the thresholds are in percents
    -w WARN
