### PR TITLE
Implemented an AWS ELB instance health check

### DIFF
--- a/plugins/aws/check-elb-health.rb
+++ b/plugins/aws/check-elb-health.rb
@@ -1,0 +1,110 @@
+#!/usr/bin/env ruby
+#
+# Checks an ELB's health status and report back
+# ===
+#
+# Copyright (c) 2012, Panagiotis Papadomitsos <pj@ezgr.net>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'net/http'
+require 'uri'
+require 'right_aws'
+
+class AwsElbCheck < Sensu::Plugin::Check::CLI
+
+    option :aws_access_key,
+        :short => '-a AWS_ACCESS_KEY',
+        :long => '--aws-access-key AWS_ACCESS_KEY',
+        :description => "AWS Access Key. Either set ENV['AWS_ACCESS_KEY_ID'] or provide it as an option",
+        :required => true,
+        :default => ENV['AWS_ACCESS_KEY_ID']
+
+    option :aws_secret_access_key,
+        :short => '-s AWS_SECRET_ACCESS_KEY',
+        :long => '--aws-secret-access-key AWS_SECRET_ACCESS_KEY',
+        :description => "AWS Secret Access Key. Either set ENV['AWS_SECRET_ACCESS_KEY'] or provide it as an option",
+        :required => true,
+        :default => ENV['AWS_SECRET_ACCESS_KEY']
+
+    option :aws_region,
+        :short => '-r AWS_REGION',
+        :long => '--aws-region REGION',
+        :description => "AWS Region (such as eu-west-1 or us-west-1). If you do not specify a region, it will automatically be detected by the server the script is run on",
+        :required => false
+
+    option :elb_id,
+        :short => '-e ELB_ID',
+        :long => '--elb-id ELB_ID',
+        :description => 'The Elastic Load Balancer name of which you want to check the health',
+        :required => true
+
+    option :instances,
+        :short => '-i INSTANCES',
+        :long => '--instances INSTANCES',
+        :description => 'Comma separated list of specific instances IDs inside the ELB of which you want to check the health',
+        :required => false
+
+    option :verbose,
+        :short => '-v',
+        :long => '--verbose',
+        :description => 'Enable a little bit more verbose reports about instance health',
+        :boolean => true,
+        :required => false,
+        :default => false
+
+    def run
+        begin
+            aws_region = (config[:aws_region].nil? || config[:aws_region].empty?) ? query_instance_region : config[:aws_region]
+            elb = RightAws::ElbInterface.new(config[:aws_access_key], config[:aws_secret_access_key], { 
+                :logger => Logger.new('/dev/null'), 
+                :cache => false,
+                :server => "elasticloadbalancing.#{aws_region}.amazonaws.com" })
+
+            if config[:instances]
+                instances = config[:instances].split(',')
+                health = elb.describe_instance_health(config[:elb_id], instances)
+            else
+                health = elb.describe_instance_health(config[:elb_id])
+            end
+        rescue Exception => e
+            critical "An issue occured while communicating with the AWS EC2 API: #{e.message}"
+        end
+
+        if health
+            unhealthy_instances = Hash.new              
+            health.each do |instance|
+                 unhealthy_instances[instance[:instance_id]] = instance[:state] unless instance[:state].eql?('InService')
+            end
+            unless unhealthy_instances.empty?
+                if config[:verbose]
+                    critical "Unhealthy instances detected: #{unhealthy_instances.map{|id,state| '[' + id + '::' + state + ']' }.join(' ') }"
+                else                    
+                    critical "Detected [#{unhealthy_instances.size}] unhealthy instances"
+                end
+            else
+                ok 'All instances healthy!'
+            end
+        else
+            critical 'Failed to retrieve ELB instance health data'
+        end
+    end
+
+    private
+
+    def query_instance_region
+        begin
+            instance_az = nil
+            Timeout.timeout(3) do
+                instance_az = Net::HTTP.get(URI('http://169.254.169.254/latest/meta-data/placement/availability-zone/'))
+            end            
+            instance_az[0...-1]
+        rescue Exception => e
+            raise "Cannot obtain this instance's Availability Zone. Maybe not running on AWS? Message was: #{e.message}" 
+        end
+    end
+
+end


### PR DESCRIPTION
Implemented an AWS ELB instance health check. It automatically detects your AWS region if you don't specify one (but this means you will be wanting to check an ELB on the same region as the server that's running the check). You will want to run this on the Sensu server with the Sensu server as a subscriber since it doesn't apply to a server/role but to an external service.
