### PR TITLE
Percona cluster size plugin

### DIFF
--- a/plugins/percona-cluster/percona-cluster-size.rb
+++ b/plugins/percona-cluster/percona-cluster-size.rb
@@ -1,0 +1,64 @@
+#!/usr/bin/env ruby
+#
+# Percona Cluster Size Plugin
+# ===
+#
+# This plugin checks the number of servers in the Percona cluster and warns you according to specified limits
+#
+# Copyright 2012 Chris Alexander <chris.alexander@import.io>, import.io
+# Based on the MySQL Health Plugin by Panagiotis Papadomitsos
+#
+# Depends on mysql:
+# gem install mysql
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'mysql'
+
+class CheckPerconaClusterSize < Sensu::Plugin::Check::CLI
+
+  option :user,
+         :description => "MySQL User",
+         :short => '-u USER',
+         :long => '--user USER',
+         :default => 'root'
+
+  option :password,
+         :description => "MySQL Password",
+         :short => '-p PASS',
+         :long => '--password PASS',
+         :required => true
+
+  option :hostname,
+         :description => "Hostname to login to",
+         :short => '-h HOST',
+         :long => '--hostname HOST',
+         :default => 'localhost'
+
+  option :expected,
+         :description => "Number of servers expected in the cluster",
+         :short => '-e NUMBER',
+         :long => '--expected NUMBER',
+         :default => 1
+
+  def run
+    begin
+        db = Mysql.real_connect(config[:hostname], config[:user], config[:password], config[:database])
+        cluster_size = db.
+            query("SHOW GLOBAL STATUS LIKE 'wsrep_cluster_size'").
+            fetch_hash().
+            fetch('Value').
+            to_i
+	critical "Expected to find #{config[:expected]} nodes, found #{cluster_size}" if cluster_size != config[:expected].to_i
+	ok "Expected to find #{config[:expected]} nodes and found those #{cluster_size}" if cluster_size == config[:expected].to_i
+    rescue Mysql::Error => e
+        critical "Percona MySQL check failed: #{e.error}"
+    ensure
+        db.close if db
+    end
+  end
+
+end


### PR DESCRIPTION
Percona Cluster is a MySQL fork which provides many additional features, one of which is the ability to run MySQL in a multi-master configuration.

This plugin solves one of our problems with monitoring Percona in that we want to make sure we still have 3 servers in the cluster at all times. It monitors the size of the cluster, as reported by the global status key, and errors if it is not equal to the desired number as set up in monitoring.
