### PR TITLE
Rework check-procs.rb to use sys/proctable rather than ps shellout.

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -11,6 +11,9 @@
 #
 # Requires WMI for Windows support.
 #
+# This should work better than shelling to 'ps', since Proctable should
+# abstract platform differences, but it's untested
+#
 # Examples:
 #
 #   # chef-client is running


### PR DESCRIPTION
Hi,

This is a quick change to use sys/proctable rather than ps. I gave this a quick test through and it seems to work for me. But please test thoroughly in your environment before deploying to production =)

It should work on Windows as sys/proctable is supported there as well but I don't have any Windows systems to test this with. Please test Windows if you have it and let me know if it breaks.

Thanks
-Miah
