### PR TITLE
REPLACE SQL command in MySQL graphite metrics

### DIFF
--- a/plugins/mysql/mysql-graphite.rb
+++ b/plugins/mysql/mysql-graphite.rb
@@ -103,6 +103,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
         'Com_flush' =>          'flush',
         'Com_insert' =>         'insert',
         'Com_purge' =>          'purge',
+	'Com_replace' =>	'replace',
         'Com_rollback' =>       'rollback',
         'Com_select' =>         'select',
         'Com_set_option' =>     'set_option',


### PR DESCRIPTION
Add Com_replace(named commands.replace) counter into MySQL metric for graphite as MySQL REPLACE is commonly used command
