### PR TITLE
IOStat Extended Metrics plugin

### DIFF
--- a/plugins/system/iostat-extended-metrics.rb
+++ b/plugins/system/iostat-extended-metrics.rb
@@ -1,0 +1,82 @@
+#!/usr/bin/env ruby
+#
+# IOStat Extended Metrics Plugin
+#
+# This plugin collects extended iostat data (iowait -x) for a 
+# specified disk or all disks. Output is in Graphite format. 
+# See `man iostat` for detailed explaination of each field:
+#
+#   rrqms,wrqms,rs,ws,rsecs,wsecs,avgrq_sz,
+#   avgqu_sz,await,svctm,percent_util
+#
+# Bethany Erskine <bethany@paperlesspost.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/metric/cli'
+require 'socket'
+
+class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
+
+  option :scheme,
+    :description => "Metric naming scheme, text to prepend to .$parent.$child",
+    :short => "-s SCHEME",
+    :long => "--scheme SCHEME",
+    :default => "#{Socket.gethostname}.vmstat"
+
+  option :disk,
+    :description => "Disk to gather stats for",
+    :short => "-d DISK",
+    :long => "--disk DISK",
+    :required => false 
+
+  def parse_results(output)
+    metrics = {}
+    result = output.split("\n")
+    result.each do |line|
+      line.strip!
+      parts = line.split(" ")
+      next unless parts.size == 12
+      next if parts[0] == "Device:"
+      key = parts[0]
+      metrics[key] = {
+        :rrqms => parts[1],
+        :wrqms => parts[2],
+        :rs => parts[3],
+        :ws => parts[4],
+        :rsecs => parts[5],
+        :wsecs => parts[6],
+        :avgrq_sz => parts[7],
+        :avgqu_sz => parts[8],
+        :await => parts[9],
+        :svctm => parts[10],
+        :percent_util => parts[11]
+        }
+    end
+    metrics
+  end
+
+  def run
+    disk = config[:disk]
+    if disk.nil?
+      raw = `iostat -x`
+      stats = parse_results(raw)
+    else
+      disk_short = File.basename(disk)
+      raw = `iostat -xd #{disk}`
+      stats = parse_results(raw)
+    end
+     
+    timestamp = Time.now.to_i
+
+    stats.each do |disk, metrics|
+      metrics.each do |metric, value|
+        output [config[:scheme], disk, metric].join("."), value, timestamp
+      end
+    end
+    ok
+  end 
+
+end


### PR DESCRIPTION
Iostat Extended Metrics plugin gathers data from `iostat -x` and
outputs the following metrics in Graphite format:
-     rrqms: The number of read requests merged per second that were queued to the device.
-     wrqms: The number of write requests merged per second that were queued to the device.
-     rs: The  number  of read requests that were issued to the device per second.
-     ws: The number of write requests that were issued to the device per second.
-     rsec_s: The number of sectors read from the device per second.
-     wsec_s: The number of sectors written to the device per second.
-     avgrq_sz: The average size (in sectors) of the requests that were issued to the device.
-     avgqu_sz: The average queue length of the requests that were issued to the device.
-     await: The average  time  (in milliseconds) for I/O requests issued to the device             to be served. This includes the time spent by the requests in queue and the time spent servicing them.
-     svctm:  The average service time (in milliseconds) for I/O requests that were issued to the device. Warning! Do not trust this field any more. This field will be removed in a future sysstat version.
-     percent_util: Percentage  of CPU time during which I/O requests were issued to the device (bandwidth utilization for the device). Device saturation occurs when this value is close to 100%.
