### PR TITLE
message update for hipchat - notification if available, otherwise output

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -13,10 +13,12 @@ class HipChatNotif < Sensu::Handler
 
   def handle
     hipchatmsg = HipChat::Client.new(settings["hipchat"]["apikey"])
+    message = @event['check']['notification'] || @event['check']['output']
+
     if @event['action'].eql?("resolve")
-      hipchatmsg[settings["hipchat"]["room"]].send('Sensu', "RESOLVED - [#{event_name}] - #{@event['check']['notification']}.", :color => 'green')
+      hipchatmsg[settings["hipchat"]["room"]].send('Sensu', "RESOLVED - [#{event_name}] - #{message}.", :color => 'green')
     else
-      hipchatmsg[settings["hipchat"]["room"]].send('Sensu', "ALERT - [#{event_name}] - #{@event['check']['notification']}.", :color => 'red', :notify => true)
+      hipchatmsg[settings["hipchat"]["room"]].send('Sensu', "ALERT - [#{event_name}] - #{message}.", :color => 'red', :notify => true)
     end
   end
 


### PR DESCRIPTION
Enhance message output in hipchat with @event['check']['output'] if @event['check']['notification'] isn't set
