### PR TITLE
make mailer emails a little more informational

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -40,7 +40,7 @@ class Mailer < Sensu::Handler
             #{@event['check']['output']}
             Host: #{@event['client']['name']}
             Timestamp: #{Time.at(@event['check']['issued'])}
-            IP Address:  #{@event['client']['address']}
+            Address:  #{@event['client']['address']}
             Check Name:  #{@event['check']['name']}
             Command:  #{@event['check']['command']}
             Status:  #{@event['check']['status']}


### PR DESCRIPTION
I thought the default body of the email could use more information.  If people think this is more valuable, merge her in.
