### PR TITLE
constrain to mail 2.4 gem series for mailer handler

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -11,6 +11,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
+gem 'mail', '~> 2.4.0'
 require 'mail'
 require 'timeout'
 


### PR DESCRIPTION
I spent way too much time trying to figure why this wouldn't work out of the box.  The mail 2.5 series in causing issues trying to force secure mail.

I felt it best to constrain this to 2.4 series as 2.4.4 is tested and working.
