### PR TITLE
Make RabbitMQ stats safer for idle machines

### DIFF
--- a/plugins/rabbitmq/rabbitmq-overview-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-overview-metrics.rb
@@ -99,12 +99,16 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
     output "#{config[:scheme]}.queue_totals.messages_ready.rate", overview['queue_totals']['messages_ready_details']['rate'], timestamp
 
     # overview['message_stats']['publish']
-    output "#{config[:scheme]}.message_stats.publish.count", overview['message_stats']['publish'], timestamp
-    output "#{config[:scheme]}.message_stats.publish.rate", overview['message_stats']['publish_details']['rate'], timestamp
+    if overview['message_stats']['publish'] then 
+      output "#{config[:scheme]}.message_stats.publish.count", overview['message_stats']['publish'], timestamp
+      output "#{config[:scheme]}.message_stats.publish.rate", overview['message_stats']['publish_details']['rate'], timestamp 
+    end
 
     # overview['message_stats']['deliver_no_ack']
-    output "#{config[:scheme]}.message_stats.deliver_no_ack.count", overview['message_stats']['deliver_no_ack'], timestamp
-    output "#{config[:scheme]}.message_stats.deliver_no_ack.rate", overview['message_stats']['deliver_no_ack_details']['rate'], timestamp
+    if overview['message_stats']['deliver_no_ack_details'] then 
+      output "#{config[:scheme]}.message_stats.deliver_no_ack.count", overview['message_stats']['deliver_no_ack'], timestamp
+      output "#{config[:scheme]}.message_stats.deliver_no_ack.rate", overview['message_stats']['deliver_no_ack_details']['rate'], timestamp
+    end
 
     # overview['message_stats']['deliver_get']
     output "#{config[:scheme]}.message_stats.deliver_get.count", overview['message_stats']['deliver_get'], timestamp


### PR DESCRIPTION
Currently if you deploy the rabbitmq-overview-metrics.rb to a new installation of rabbitmq with no stats the script will bomb out.  Wrapped a couple of those lines to make sure that the hash exists before attempting to print.  
