### PR TITLE
Update slaveLag metric to appear under mysql group

### DIFF
--- a/plugins/mysql/mysql-graphite.rb
+++ b/plugins/mysql/mysql-graphite.rb
@@ -191,7 +191,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
           if key == 'Seconds_Behind_Master' and value.nil?
             value = -1
           end
-          output "#{config[:scheme]}.general.#{metrics['general'][key]}", value
+          output "#{config[:scheme]}.mysql.general.#{metrics['general'][key]}", value
         end
       end
     rescue


### PR DESCRIPTION
Should the slaveLag metric appear under the mysql.general metric group instead of in a general group at a peer level to the mysql one?
