### PR TITLE
Remove hard-coded "mysql" string from metric names

### DIFF
--- a/plugins/mysql/mysql-graphite.rb
+++ b/plugins/mysql/mysql-graphite.rb
@@ -177,7 +177,7 @@ class Mysql2Graphite < Sensu::Plugin::Metric::CLI::Graphite
     results.each do |row|
       metrics.each do |category, var_mapping|
         if var_mapping.has_key?(row["Variable_name"]) then
-          output "#{config[:scheme]}.mysql.#{category}.#{var_mapping[row["Variable_name"]]}", row["Value"]
+          output "#{config[:scheme]}.#{category}.#{var_mapping[row["Variable_name"]]}", row["Value"]
         end
       end
     end


### PR DESCRIPTION
The default scheme includes "mysql" so I do not think it needs to be hard-coded in the metric names.  Otherwise you end up with "#{Socket.gethostname}.mysql.mysql.category.metric".  Also, the slave metric does not have "mysql" hardcoded, so the default settings cause the slaveLag metric to be stored in a "general" directory as a peer to the "mysql" directory, instead of within the "mysql.general" directory with the rest of the metrics.
