### PR TITLE
fix default scheme '.load_avg' double up in load-metrics.rb

### DIFF
--- a/plugins/system/load-metrics.rb
+++ b/plugins/system/load-metrics.rb
@@ -18,7 +18,7 @@ class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
     :description => "Metric naming scheme, text to prepend to .$parent.$child",
     :long => "--scheme SCHEME",
-    :default => "#{Socket.gethostname}.load_avg"
+    :default => "#{Socket.gethostname}"
 
   def convert_integers(values)
     values.each_with_index do |value, index|


### PR DESCRIPTION
the default scheme option causes a double up of the ".load_avg" name

i.e. statistics end up with hostname.load_avg.load_avg.one etc..
