### PR TITLE
Update handlers/notification/pushover.rb

### DIFF
--- a/handlers/notification/pushover.rb
+++ b/handlers/notification/pushover.rb
@@ -37,7 +37,7 @@ class Pushover < Sensu::Handler
         req.set_form_data(params)
         res = Net::HTTP.new(url.host, url.port)
         res.use_ssl = true
-        res.verify_mode = OpenSSL::SSL::VERIFY_PEER
+        #res.verify_mode = OpenSSL::SSL::VERIFY_PEER
         res.start { |http| http.request(req) }
         puts 'pushover -- sent alert for ' + event_name + ' to pushover.'
       end


### PR DESCRIPTION
I get this error if verify_mode is  set :

{"timestamp":"2013-01-23T14:34:21.393489+1000","message":"/usr/lib/ruby/1.8/net/http.rb:586:in `connect': SSL_connect returned=1 errno=0 state=SSLv3 read server certificate B: certificate verify failed (OpenSSL::SSL::SSLError)","level":"info"}

so to get it to work for me I just commented out this line.

I don't know much about ruby and its http library, so maybe someone else can shed some light
