### PR TITLE
Clarify configuration requirements

### DIFF
--- a/handlers/notification/README.md
+++ b/handlers/notification/README.md
@@ -2,7 +2,7 @@
 
 ## mailer
 
-The following three configuration variables is optional if you want mailer to use remote SMTP settings
+The following three configuration variables must be set if you want mailer to use remote SMTP settings:
 
     smtp_address - defaults to "localhost"
     smtp_port - defaults to "25"


### PR DESCRIPTION
Fix grammatical error by rewording instructions.
