### PR TITLE
Removing UTF8 character

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -4,7 +4,7 @@
 #
 # This handler formats alerts as mails and sends them off to a pre-defined recipient.
 #
-# Copyright 2012 Pål-Kristian Hamre (https://github.com/pkhamre | http://twitter.com/pkhamre)
+# Copyright 2012 Pal-Kristian Hamre (https://github.com/pkhamre | http://twitter.com/pkhamre)
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.


### PR DESCRIPTION
When using the official Opscode repository for chef-client, running it in CRON mode, that UTF8 characters prevents Chef from running successfully. As UTF8 is not available as language by default in CRON.
