### PR TITLE
Resolve Ruby syntax issue in plugins/aws/check-elb-health.rb

### DIFF
--- a/plugins/aws/check-elb-health.rb
+++ b/plugins/aws/check-elb-health.rb
@@ -57,7 +57,7 @@ class ELBHealth < Sensu::Plugin::Check::CLI
   option :instances,
     :short => '-i INSTANCES',
     :long => '--instances INSTANCES',
-    :description => 'Comma separated list of specific instances IDs inside the ELB of which you want to check the health',
+    :description => 'Comma separated list of specific instances IDs inside the ELB of which you want to check the health'
 
   option :verbose,
     :short => '-v',


### PR DESCRIPTION
When trying to upload this to chef server as a cookbook file, I got a ruby error because of the trailing comma in the parameters definitions
