### PR TITLE
check-mtime: send warning method instead of warn

### DIFF
--- a/plugins/files/check-mtime.rb
+++ b/plugins/files/check-mtime.rb
@@ -33,7 +33,7 @@ class Mtime < Sensu::Plugin::Check::CLI
   option :warning_age,
     :description => 'Warn if mtime greater than provided age in seconds',
     :short => '-w SECONDS',
-    :long => '--warn SECONDS'
+    :long => '--warning SECONDS'
 
   option :critical_age,
     :description => 'Critical if mtime greater than provided age in seconds',


### PR DESCRIPTION
fixed plugin to be able to generate a warning status
