### PR TITLE
haproxy-metrics updates

### DIFF
--- a/plugins/haproxy/haproxy-metrics.rb
+++ b/plugins/haproxy/haproxy-metrics.rb
@@ -3,6 +3,9 @@
 # Pull haproxy metrics for backends
 # ===
 #
+# If you are occassionally seeing "nil output" from this check, make sure you have
+# sensu-plugin >= 0.1.7. This will provide a better error message.
+#
 # TODO: backend pool single node stats.
 #
 # Copyright 2012 Pete Shima <me@peteshima.com>, Joe Miller <https://github.com/joemiller>


### PR DESCRIPTION
- new flag `--server-metrics` from @nstielau to report backend server metrics
- new flags `--retries` and `--retry_interval` to make the get_stats() attempts configurable
- improved error handling in cases where stats are not returned by haproxy
