### PR TITLE
Returns UNKNOWN status instead of critical if your request is malformed

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -90,8 +90,8 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
 
     begin
       res = http.request(req)
-    rescue
-      unknown "Script error: " + $!.to_s
+    rescue => e
+      unknown "#{e.class}: #{e.message}"
     end
 
     case res.code


### PR DESCRIPTION
Before:
    ./check-http.rb -h nil -p /
    CheckHTTP CRITICAL: Connection error: getaddrinfo: nodename nor servname provided,  or not known

After:
     ./check-http.rb -h nil -p /
    CheckHTTP UNKNOWN: getaddrinfo: nodename nor servname provided, or not known
