### PR TITLE
set the @message parameter for logstash

### DIFF
--- a/handlers/notification/logstash.rb
+++ b/handlers/notification/logstash.rb
@@ -41,7 +41,6 @@ class LogstashHandler < Sensu::Handler
       :@tags => ["sensu-#{action_to_string}"],
       :@message => @event['check']['output'],
       :@fields => {
-        :short_message => "#{action_to_string} - #{event_name}: #{@event['check']['notification']}",
         :host          => @event['client']['name'],
         :timestamp     => @event['check']['issued'],
         :address       => @event['client']['address'],


### PR DESCRIPTION
Currently the @message parameter is not set on the sensu logstash output.  @fields.full_message looks like a good choice and becomes redundant in the fields then.
