### PR TITLE
fix to nginx-metrics.rb to stop output of blank lines to metric handler

### DIFF
--- a/plugins/nginx/nginx-metrics.rb
+++ b/plugins/nginx/nginx-metrics.rb
@@ -72,15 +72,18 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
     end # until
 
     response.body.split(/\r?\n/).each do |line|
-      if connections = line.match(/^Active connections:\s+(\d+)/).to_a
+      if line.match(/^Active connections:\s+(\d+)/)
+        connections = line.match(/^Active connections:\s+(\d+)/).to_a
         output "#{config[:scheme]}.active_connections", connections[1]
       end
-      if requests = line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/).to_a
+      if line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/)
+        requests = line.match(/^\s+(\d+)\s+(\d+)\s+(\d+)/).to_a
         output "#{config[:scheme]}.accepted", requests[1]
         output "#{config[:scheme]}.handled", requests[2]
         output "#{config[:scheme]}.handles", requests[3]
       end
-      if queue = line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/).to_a
+      if line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/)
+        queue = line.match(/^Reading:\s+(\d+).*Writing:\s+(\d+).*Waiting:\s+(\d+)/).to_a
         output "#{config[:scheme]}.reading", queue[1]
         output "#{config[:scheme]}.writing", queue[2]
         output "#{config[:scheme]}.waiting", queue[3]


### PR DESCRIPTION
issue #223  re: extra blank lines in nginx-metrics.

first pull request - apologies if I didn't get this right.
