### PR TITLE
Officehours

### DIFF
--- a/mutators/officehours.rb
+++ b/mutators/officehours.rb
@@ -33,10 +33,10 @@ t = Time.now
 
 # Verify if we're opened for business
 if t.wday.between?(1, 5)
-    if t.between?(Time.parse('9:00'), Time.parse('17:00'))
-          event.merge!(:mutated => true, :office_hours => true)
-            end
-            end
+  if t.between?(Time.parse('9:00'), Time.parse('17:00'))
+    event.merge!(:mutated => true, :office_hours => true)
+  end
+end
 
 # output modified event
 puts event.to_json


### PR DESCRIPTION
Check if we're at the office or not. To allow handlers to decide if it
should notify or not. For example, don't alert us for development
environments on a Saturday at 4am.
