### PR TITLE
Update mailer.rb

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -67,7 +67,7 @@ class Mailer < Sensu::Handler
           body    body
         end
 
-        puts 'mail -- sent alert for ' + short_name + ' to ' + params[:mail_to]
+        puts 'mail -- sent alert for ' + short_name + ' to ' + params[:mail_to].to_s
       end
     rescue Timeout::Error
       puts 'mail -- timed out while attempting to ' + @event['action'] + ' an incident -- ' + short_name


### PR DESCRIPTION
It's possible for params[:mail_to] to be an array, and have the alert sent to multiple users. But then you get `TypeError: can't convert Array into String`. This works in both cases
