### PR TITLE
Cleaning up tempdb handler

### DIFF
--- a/handlers/metrics/tempodb.rb
+++ b/handlers/metrics/tempodb.rb
@@ -1,9 +1,14 @@
 #!/usr/bin/env ruby
 #
+# Sensu Handler: tempodb
+#
 # Copyright 2012 TempoDB, Inc.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
+#
+# Dependencies:
+#   tempodb gem: gem install tempodb
 #
 # Compatible checks should generate output in the format:
 #   metric.path.one value timestamp\n
@@ -15,29 +20,36 @@ require 'tempodb'
 
 class TempoDBSensu < Sensu::Handler
 
-    def handle
+  def handle
+    client = TempoDB::Client.new(
+      settings['tempodb']['api_key'],
+      settings['tempodb']['api_secret']
+    )
 
-        client = TempoDB::Client.new( settings['tempodb']['api_key'], settings['tempodb']['api_secret'] )
-        metrics = @event['check']['output']
-        time = Time.now
-        data = Array.new
+    metrics = @event['check']['output']
+    time = Time.now
+    data = []
 
-        # loop through metrics, separated by \n, pull out each metric and add to data array
-        metrics.split("\n").each do |metric|
-            m = metric.split("\t")
-            key = m[0]
-            v = m[1].to_f
-            data.push( { 'key' => key, 'v' => v } )
-        end
+    # loop through metrics, separated by \n, pull out each metric and add to data array
+    metrics.split("\n").each do |metric|
+      m = metric.split()
 
-        begin
-            timeout(3) do
-                client.write_bulk(time, data)
-            end
-        rescue Timeout::Error
-            puts "tempodb -- timed out while sending bulk write"
-        rescue => error
-            puts "tempodb -- failed to send bulk write : #{error}"
-        end
+      # Should match format metric.path.two value timestamp
+      next unless m.count == 3
+
+      key = m[0]
+      v = m[1].to_f
+      data.push({ 'key' => key, 'v' => v })
     end
+
+    begin
+      timeout(3) do
+        client.write_bulk(time, data)
+      end
+    rescue Timeout::Error
+      puts "tempodb -- timed out while sending bulk write"
+    rescue => error
+      puts "tempodb -- failed to send bulk write : #{error}"
+    end
+  end
 end


### PR DESCRIPTION
- Whitespace
- Rubocop fixes
- Validating metrics format
- Splitting on whitespace instead of tabs
