### PR TITLE
SNS Handler Improvements

### DIFF
--- a/handlers/notification/sns.rb
+++ b/handlers/notification/sns.rb
@@ -21,7 +21,7 @@ class SnsNotifier < Sensu::Handler
   def topic_arn
     settings['sns']['topic_arn']
   end
-  
+
   def region
     settings['sns']['region'] || 'us-east-1'
   end
@@ -36,7 +36,7 @@ class SnsNotifier < Sensu::Handler
 
   def handle
     AWS.config(:region => region)
-    
+
     sns = AWS::SNS.new
 
     t = sns.topics[topic_arn]


### PR DESCRIPTION
I've added the ability to configure the region for the Amazon SNS handler, added a subject parameter to the options for better display in e-mail subscribers and removed the '.' from the end of the message output as this may cause confusion in the output of the event message.
