### PR TITLE
Clone of graphite check with the ability to specify wildcard targets

### DIFF
--- a/plugins/graphite/graphite.rb
+++ b/plugins/graphite/graphite.rb
@@ -366,7 +366,7 @@ class Graphite < Sensu::Plugin::Check::CLI
       critical fatals_string if fatals.size > 0
       critical criticals_string if critical_errors.size > 0
       warning warnings_string if warnings.size > 0
-    else 
+    else
       critical fatals_string if fatals.size > 0
       critical criticals_string if critical_errors.size > 0
       warning warnings_string if warnings.size > 0


### PR DESCRIPTION
Because the changes I've made are quite significant and my Ruby skills aren't great I didn't want to risk breaking the original graphite check by Ulf Mansson.

The original check only really supports statically named Graphite targets such as "foo.bar.baz", whereas this change allows wildcard targets such as "*.bar.baz". It will list every target that which triggers the alert threshold in the alert output, e.g:

./graphite-wildcards.rb -h localhost:80 -t _._.*.os.memory.used -g 10,10000 -p 2hours
Graphite CRITICAL: The metric x.y.z.os.memory.used is 3374571520.0 that is higher than max allowed 10000
The metric x.y.z.os.memory.used is 9113530368.0 that is higher than max allowed 10000
The metric x.y.z.os.memory.used is 32342913024.0 that is higher than max allowed 10000
The metric x.y.z.os.memory.used is 8934682624.0 that is higher than max allowed 10000

Please shout if I've managed to make a rookie mistake, or if there's any other improvements I can make!
