### PR TITLE
New features for graphite check

### DIFF
--- a/plugins/graphite/graphite.rb
+++ b/plugins/graphite/graphite.rb
@@ -197,6 +197,7 @@ class Graphite < Sensu::Plugin::Check::CLI
       count = values_size if count > values_size
       while count > 0
         values_size -= 1
+        break if values[values_size].nil?
         count -= 1 if values[values_size][0]
         ret.push(values[values_size]) if values[values_size][0]
       end


### PR DESCRIPTION
Changed functionality so that each check (with exception to increasing) may be configured with a -g option to specify that the value should not be greater than whatever the check is calculating. This functionality defaults to less than.

Added a percentile check whereby the percentile to be calculated may be specified along with the a percentage by which the last value may be greater or less than the percentile.

Added a percentage above average check whereby a percentage of the last value may not be greater or less than the mean over the time series.
