### PR TITLE
Check Testing Discussion

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,4 +8,5 @@ end
 group :test do
   gem "sensu-plugin"
   gem "rubocop"
+  gem "rspec"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,21 @@ GEM
   remote: https://rubygems.org/
   specs:
     ast (1.0.2)
+    diff-lcs (1.1.3)
     json (1.7.5)
     mixlib-cli (1.2.2)
     parser (2.0.0.beta4)
       ast (~> 1.0)
       slop (~> 3.4)
     rainbow (1.1.4)
+    rspec (2.14.1)
+      rspec-core (~> 2.14.0)
+      rspec-expectations (~> 2.14.0)
+      rspec-mocks (~> 2.14.0)
+    rspec-core (2.14.4)
+    rspec-expectations (2.14.0)
+      diff-lcs (>= 1.1.3, < 2.0)
+    rspec-mocks (2.14.2)
     rubocop (0.8.2)
       parser (>= 2.0.0.beta1, <= 2.0.0)
       rainbow (>= 1.1.4)
@@ -20,5 +29,6 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  rspec
   rubocop
   sensu-plugin

--- a/plugins/dns/check-dns.rb
+++ b/plugins/dns/check-dns.rb
@@ -68,25 +68,88 @@ class DNS < Sensu::Plugin::Check::CLI
   end
 
   def run
-    unknown "No domain specified" unless config[:domain]
-    entries = resolve_domain
-    if entries.length.zero?
-      if config[:warn_only]
-        warning "Could not resolve #{config[:domain]}"
-      else
-        critical "Could not resolve #{config[:domain]}"
-      end
+    if config[:domain].nil?
+      unknown "No domain specified"
     else
-      if config[:result]
-        if entries.include?(config[:result])
-          ok "Resolved #{config[:domain]} including #{config[:result]}"
+      entries = resolve_domain
+      if entries.length.zero?
+        if config[:warn_only]
+          warning "Could not resolve #{config[:domain]}"
         else
-          critical "Resolved #{config[:domain]} did not include #{config[:result]}"
+          critical "Could not resolve #{config[:domain]}"
         end
       else
-        ok "Resolved #{config[:domain]} #{config[:type]} records"
+        if config[:result]
+          if entries.include?(config[:result])
+            ok "Resolved #{config[:domain]} including #{config[:result]}"
+          else
+            critical "Resolved #{config[:domain]} did not include #{config[:result]}"
+          end
+        else
+          ok "Resolved #{config[:domain]} #{config[:type]} records"
+        end
       end
     end
   end
 
 end
+
+# Load rspec tests if we're being rspec'd
+if File.basename($0) == 'rspec'
+  require 'rspec'
+
+  # This method is added in a pull request
+  DNS.disable_autorun if DNS.respond_to?('disable_autorun')
+
+  describe DNS, "run" do
+    it "returns unknown if there is no domain specified" do
+      dns = DNS.new
+      dns.should_receive("unknown")
+      dns.run
+    end
+
+    it "returns ok if entries are resolved" do
+      dns = DNS.new
+      dns.config[:domain] = 'www.google.com'
+      dns.should_receive("resolve_domain") {['a']}
+      dns.should_receive("ok")
+      dns.run
+    end
+
+    it "returns ok if specifed entry is included" do
+      dns = DNS.new
+      dns.config[:domain] = 'www.google.com'
+      dns.config[:result] = '1.2.3.4'
+      dns.should_receive("resolve_domain") {['1.2.3.4']}
+      dns.should_receive("ok")
+      dns.run
+    end
+
+    it "returns critical if specifed entry is not included" do
+      dns = DNS.new
+      dns.config[:domain] = 'www.google.com'
+      dns.config[:result] = '1.2.3.4'
+      dns.should_receive("resolve_domain") {['4.3.2.1']}
+      dns.should_receive("critical")
+      dns.run
+    end
+
+    it "returns critical without records" do
+      dns = DNS.new
+      dns.config[:domain] = 'www.google.com'
+      dns.should_receive("resolve_domain") {[]}
+      dns.should_receive("critical")
+      dns.run
+    end
+
+    it "returns warning if specified" do
+      dns = DNS.new
+      dns.config[:domain] = 'www.google.com'
+      dns.config[:warn_only] = true
+      dns.should_receive("resolve_domain") {[]}
+      dns.should_receive("warning")
+      dns.run
+    end
+  end
+end
+


### PR DESCRIPTION
Checks are getting more complex, and multiple authors are editing the same checks.  Testing can help clean up these workflows.  Let's see if we can get a clean standard for testing checks.

Questions:
- Does it make sense to try to place the tests in the check (rather than in a test/spec directory)?  
- Do we want to use minitest (instead of rspec)

I'm fine with minitest, I just used rspec because I thought of it first (sensu-plugin uses minitest, so we should probably standardize on that).

I like having the tests self-contained in the check, as long as it doesn't cause any runtime errors or performance degradation (which I think is easily achieved with a quick check of `$0`).

This would be integrated into the CI scripts as well.

This also depends on this sensu-plugin pull (https://github.com/sensu/sensu-plugin/pull/46), which allows the disabling of autorun behavior, so tests can load check classes without them running on process exit. 

Thoughts?
