### PR TITLE
Add check-fstab-mounts plugin (Linux only)

### DIFF
--- a/plugins/system/check-fstab-mounts.rb
+++ b/plugins/system/check-fstab-mounts.rb
@@ -1,0 +1,54 @@
+#!/usr/bin/env ruby
+#
+# Check fstab Mounts Plugin
+# ===
+#
+# Check /proc/mounts to ensure all filesystems of the requested type(s) from
+# fstab are currently mounted.  If no fstypes are specified, will check all
+# entries in fstab.
+#
+# Peter Fern <ruby@0xc0dedbad.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+
+class CheckFstabMounts < Sensu::Plugin::Check::CLI
+  option :fstypes,
+    :description => 'Filesystem types to check, comma-separated',
+    :short => '-t TYPES',
+    :long => '--types TYPES',
+    :proc => proc {|a| a.split(',')},
+    :required => false
+
+  def initialize
+    super
+    @fstab = IO.readlines '/etc/fstab'
+    @proc_mounts = IO.readlines '/proc/mounts'
+    @missing_mounts = []
+  end
+
+  def check_mounts
+    # check by mount destination, which is col 2 in fstab and proc/mounts
+    @fstab.each do |line|
+      next if line =~ /^\s*#/
+      fields = line.split(/\s+/)
+      next if fields[1] == 'none'
+      next if config[:fstypes] and !config[:fstypes].include? fields[2]
+      if @proc_mounts.select {|m| m.split(/\s+/)[1] == fields[1]}.empty?
+        @missing_mounts << fields[1]
+      end
+    end
+  end
+
+  def run
+    check_mounts
+    if @missing_mounts.any?
+      critical "Mountpoint(s) #{@missing_mounts.join(',')} not mounted!"
+    else
+      ok 'All mountpoints accounted for'
+    end
+  end
+end


### PR DESCRIPTION
This plugin parses `/etc/fstab` and `/proc/mounts` to ensure that all
mountpoints specified in `fstab` are currently mounted.  Optionally
filtered by filesystem type
