### PR TITLE
Actually replace '%' with 'pct_' in keys for iostat-extended-metrics

### DIFF
--- a/plugins/system/iostat-extended-metrics.rb
+++ b/plugins/system/iostat-extended-metrics.rb
@@ -40,13 +40,13 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
       case line
       when /^(avg-cpu):/
         stage = :cpu
-        key = Regexp.last_match[1].gsub(/%/, 'pct_')
-        headers = line.split(/\s+/)
+        key = Regexp.last_match[1]
+        headers = line.gsub(/%/, 'pct_').split(/\s+/)
         headers.shift
         next
       when /^(Device):/
         stage = :device
-        headers = line.split(/\s+/).map{|h| h.gsub(/\//, '_per_')}
+        headers = line.gsub(/%/, 'pct_').split(/\s+/).map{|h| h.gsub(/\//, '_per_')}
         headers.shift
         next
       end


### PR DESCRIPTION
This fixes a stupid typo in untested code.

Sorry about the original stupidity, finally got to test this, having updated my dependent code today.
