### PR TITLE
Making log messages more informative for check-log

### DIFF
--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -71,8 +71,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
       unknown "Could not open log file: #{e}"
     end
     n_warns, n_crits = search_log
-    message "#{n_warns} warnings, #{n_crits} criticals for pattern " \
-            "#{config[:pattern]} in #{config[:log_file]}"
+    message "#{n_warns} warnings, #{n_crits} criticals for pattern #{config[:pattern]} in #{config[:log_file]}"
     if n_crits > 0
       critical
     elsif n_warns > 0


### PR DESCRIPTION
Making log messages more informative. This helps while setting up this check on multiple log files.
