### PR TITLE
Make age option an integer; use age in URL when querying API

### DIFF
--- a/plugins/sensu/check-aggregate.rb
+++ b/plugins/sensu/check-aggregate.rb
@@ -111,7 +111,6 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     issued = api_request(uri + "?age=#{config[:age]}")
     unless issued.empty?
       issued_sorted = issued.sort
-      time = nil
       time = issued_sorted.pop
       unless time.nil?
         uri += "/#{time}"


### PR DESCRIPTION
- using to_i on the option `age` fixes the following error when specifying --age/-A:

```
CheckAggregate CRITICAL: Check failed to run: String can't be coerced into Fixnum, 
["/etc/sensu/plugins/check-aggregate.rb:116:in `-'", "/etc/sensu/plugins/check-aggregate.rb:116:in 
`get_aggregate'", "/etc/sensu/plugins/check-aggregate.rb:167:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-0.1.7/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```
- adding `?age=` to the api_request in `get_aggregate`
