### PR TITLE
fix suspicious critical threshold (from 10 to 100)

### DIFF
--- a/plugins/system/check-cpu.rb
+++ b/plugins/system/check-cpu.rb
@@ -16,7 +16,7 @@ class CheckCPU < Sensu::Plugin::Check::CLI
   option :crit,
     :short => '-c CRIT',
     :proc => proc {|a| a.to_f },
-    :default => 10
+    :default => 100
 
   option :sleep,
     :long => '--sleep SLEEP',


### PR DESCRIPTION
I think the critical threshold should be 100 instead of 10.
10 is way smaller than 80 (threshold for warn), looks suspicious to me.

If I misunderstood the original idea, just silently close this pull request, please :-P

H.
