### PR TITLE
Add ignoreline and includeline options to check-disk.rb

### DIFF
--- a/plugins/system/check-disk.rb
+++ b/plugins/system/check-disk.rb
@@ -14,7 +14,6 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 
-# Sensu check class for checking disks
 class CheckDisk < Sensu::Plugin::Check::CLI
 
   option :fstype,
@@ -30,8 +29,14 @@ class CheckDisk < Sensu::Plugin::Check::CLI
     :proc => proc {|a| a.split(',') }
 
   option :ignoreline,
-    :short => '-l TEXT',
-    :proc => proc {|a| a.to_s }
+    :short => '-l PATTERN[,PATTERN]',
+    :description => 'Ignore df line(s) matching pattern(s)',
+    :proc => proc { |a| a.split(',') }
+
+  option :includeline,
+    :short => '-L PATTERN[,PATTERN]',
+    :description => 'Only include df line(s) matching pattern(s)',
+    :proc => proc { |a| a.split(',') }
 
   option :warn,
     :short => '-w PERCENT',
@@ -43,23 +48,32 @@ class CheckDisk < Sensu::Plugin::Check::CLI
     :proc => proc {|a| a.to_i },
     :default => 95
 
+  option :debug,
+      :short => '-d',
+      :long => '--debug',
+      :description => 'Output list of included filesystems'
+
   def initialize
     super
     @crit_fs = []
     @warn_fs = []
+    @line_count = 0
   end
 
   def read_df
     `df -PT`.split("\n").drop(1).each do |line|
       begin
         _fs, type, _blocks, _used, _avail, capacity, mnt = line.split
+        next if config[:includeline] && !config[:includeline].find { |x| line.match(x) }
         next if config[:fstype] && !config[:fstype].include?(type)
         next if config[:ignoretype] && config[:ignoretype].include?(type)
         next if config[:ignoremnt] && config[:ignoremnt].include?(mnt)
-        next if config[:ignoreline] && line.include?(config[:ignoreline])
+        next if config[:ignoreline] && config[:ignoreline].find { |x| line.match(x) }
+        puts line if config[:debug]
       rescue
         unknown "malformed line from df: #{line}"
       end
+      @line_count += 1
       if capacity.to_i >= config[:crit]
         @crit_fs << "#{mnt} #{capacity}"
       elsif capacity.to_i >= config[:warn]
@@ -73,7 +87,11 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def run
+    if config[:includeline] && config[:ignoreline]
+      unknown 'Do not use -l and -L options concurrently'
+    end
     read_df
+    unknown 'No filesystems found' unless @line_count > 0
     critical usage_summary unless @crit_fs.empty?
     warning usage_summary unless @warn_fs.empty?
     ok "All disk usage under #{config[:warn]}%"


### PR DESCRIPTION
This is basically a modified version of check-disk.rb in PR #280 with additional functionality, differences being:
- `-l` allows multiple (comma-separated) patterns to ignore from df output
- `-L` allows multiple patterns of df output to **only** include (mutually-exclusive with `-l`)
- both options above use regex matches so you can use wildcards, anchors, etc.
- `-d, --debug` option shows df output for testing purposes

This could potentially eliminates the need for some of the pre-existing options, however I left them in for backwards compatibility.
