### PR TITLE
Handler to remove Chef nodes terminated in EC2

### DIFF
--- a/handlers/other/chef_ec2_node.rb
+++ b/handlers/other/chef_ec2_node.rb
@@ -36,10 +36,10 @@
 #     "filters": {
 #       "ghost_nodes": {
 #         "attributes": {
-#           "event": {
-#             "check": "keepalive",
-#             "occurences": "eval: value > 2"
-#           }
+#           "check": {
+#             "name": "keepalive"
+#           },
+#           "occurences": "eval: value > 2"
 #         }
 #       }
 #     },


### PR DESCRIPTION
This handler removes a Chef node if it has been terminated in EC2 by means that do not remove the information from the Chef Server (i.e. knife), such as through the EC2 web console. 

NOTE: The implementation for correlating Sensu clients to Chef nodes in EC2 may need to be modified to fit your organization. The current implementation assumes that Sensu clients' names are the same as their instance IDs in EC2. If this is not the case, you can either sub-class this handler and override `ec2_node_exists?` in your own organization-specific handler, or modify this handler to suit your needs. 

Requires the following environment variables to be set:
- AWS_ACCESS_KEY_ID
- AWS_SECRET_ACCESS_KEY 

Requires the following Rubygems (`gem install $GEM`):
- sensu-plugin
- spice (~> 1.0.6)
- fog 
