### PR TITLE
Add critical severity option to check-redis-memory.rb on connection failure

### DIFF
--- a/plugins/redis/check-redis-memory.rb
+++ b/plugins/redis/check-redis-memory.rb
@@ -72,8 +72,11 @@ class RedisChecks < Sensu::Plugin::Check::CLI
       end
     rescue
       message = "Could not connect to Redis server on #{config[:host]}:#{config[:port]}"
-      critical message if config[:crit_conn]
-      warning message
+      if config[:crit_conn]
+        critical message
+      else
+        warning message
+      end
     end
   end
 


### PR DESCRIPTION
New boolean arg `--crit-conn-failure` will cause critical exit status rather than warning if connection to redis fails.  Useful if upstream handler(s) are filtering by severity.
