### PR TITLE
Add `interval` options to `iostat-extended-metrics`

### DIFF
--- a/plugins/system/iostat-extended-metrics.rb
+++ b/plugins/system/iostat-extended-metrics.rb
@@ -28,6 +28,12 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
     :long => "--disk DISK",
     :required => false
 
+  option :interval,
+    :description => "Period over which statistics are calculated (in seconds)",
+    :short => "-i SECONDS",
+    :long => "--interval SECONDS",
+    :default => 1
+
   def parse_results(raw)
     stats = {}
     key = nil
@@ -63,7 +69,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    cmd = 'iostat -x 1 2'
+    cmd = "iostat -x #{config[:interval]} 2"
     if config[:disk]
       cmd += " #{File.basename(config[:disk])}"
     end


### PR DESCRIPTION
Allow the user to extend the `interval` over which statistics are measured. 
This can smooth bursty averages resulting from the default 1 second interval. 
Though it's questionable whether this is a good idea, users should have the
option.
