### PR TITLE
Add additional redis info keys to skip in metrics output

### DIFF
--- a/plugins/redis/redis-graphite.rb
+++ b/plugins/redis/redis-graphite.rb
@@ -19,7 +19,9 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
   SKIP_KEYS_REGEX = ['gcc_version', 'master_host', 'master_link_status',
                      'master_port', 'mem_allocator', 'multiplexing_api', 'process_id',
                      'redis_git_dirty', 'redis_git_sha1', 'redis_version', '^role',
-                     'run_id', '^slave', 'used_memory_human', 'used_memory_peak_human']
+                     'run_id', '^slave', 'used_memory_human', 'used_memory_peak_human',
+                     'redis_mode', 'os', 'arch_bits', 'tcp_port',
+                     'rdb_last_bgsave_status', 'aof_last_bgrewrite_status']
 
   option :host,
     :short => "-h HOST",


### PR DESCRIPTION
Found some additional redis info keys that are either text-based and/or static that add no value in graphite metrics output.
