### PR TITLE
Add additional options to disk-usage-metrics.rb

### DIFF
--- a/plugins/system/disk-usage-metrics.rb
+++ b/plugins/system/disk-usage-metrics.rb
@@ -67,7 +67,7 @@ class DiskUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
     `df -PBM`.split("\n").drop(1).each do |line|
       _, _, used, avail, used_p, mnt = line.split
 
-      unless %r{/sys|/dev|/run/}.match(mnt)
+      unless %r{/sys|/dev|/run}.match(mnt)
         next if config[:ignore_mnt] && config[:ignore_mnt].find { |x| mnt.match(x) }
         next if config[:include_mnt] && !config[:include_mnt].find { |x| mnt.match(x) }
         if config[:flatten]


### PR DESCRIPTION
- Ignore mount-points by regex pattern `-i` `--ignore-mount`
- Include only specific mount-points by regex pattern `-I` `--include-mount`
- Replace subdir breaks with '_' instead of '.' using the `--flatten` option
