### PR TITLE
add delete-expired-stashes plugin

### DIFF
--- a/plugins/sensu/delete-expired-stashes.rb
+++ b/plugins/sensu/delete-expired-stashes.rb
@@ -34,7 +34,7 @@ class CheckSilenced < Sensu::Plugin::Metric::CLI::Graphite
     :default => 4567
 
   option :use_ssl,
-    :short => '-k',
+    :short => '--ssl',
     :long => '--use-ssl',
     :description => 'Use ssl when connecting to sensu-api endpoint',
     :default => false


### PR DESCRIPTION
This plugin examines stashes on the Sensu API server and deletes those with an 'expires' key whose value (epoch timestamp) has occurred in the past. The plugin outputs graphite metrics so the occurrences of expired stashes being deleted can be tracked.
