### PR TITLE
add runbook support to hipchat and mailer notifications

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -17,18 +17,18 @@ class HipChatNotif < Sensu::Handler
 
     message = @event['check']['notification'] || @event['check']['output']
 
-    # If the runbook attribute exists and is a URL, "[<a href='url'>Runbook</a>]" will be output.
-    # To control the link name, set the runbook value to the HTML output you would like.
-    if @event['check']['runbook']
+    # If the playbook attribute exists and is a URL, "[<a href='url'>playbook</a>]" will be output.
+    # To control the link name, set the playbook value to the HTML output you would like.
+    if @event['check']['playbook']
       begin
-        uri = URI.parse(@event['check']['runbook'])
+        uri = URI.parse(@event['check']['playbook'])
         if %w( http https ).include?(uri.scheme)
-          message << "  [<a href='#{@event['check']['runbook']}'>Runbook</a>]"
+          message << "  [<a href='#{@event['check']['playbook']}'>Playbook</a>]"
         else
-          message << "  Runbook:  #{@event['check']['runbook']}"
+          message << "  Playbook:  #{@event['check']['playbook']}"
         end
       rescue
-        message << "  Runbook:  #{@event['check']['runbook']}"
+        message << "  Playbook:  #{@event['check']['playbook']}"
       end
     end
 

--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -37,7 +37,7 @@ class Mailer < Sensu::Handler
       :smtp_domain => smtp_domain
     }
 
-    runbook = "Runbook:  #{@event['check']['runbook']}" if @event['check']['runbook']
+    playbook = "Playbook:  #{@event['check']['playbook']}" if @event['check']['playbook']
     body = <<-BODY.gsub(/^ {14}/, '')
             #{@event['check']['output']}
             Host: #{@event['client']['name']}
@@ -47,7 +47,7 @@ class Mailer < Sensu::Handler
             Command:  #{@event['check']['command']}
             Status:  #{@event['check']['status']}
             Occurrences:  #{@event['occurrences']}
-            #{runbook}
+            #{playbook}
           BODY
     subject = "#{action_to_string} - #{short_name}: #{@event['check']['notification']}"
 


### PR DESCRIPTION
Add runbook notification support to hipchat and mailer handlers.  If the runbook property is set the hipchat handler will attempt to convert it to a link if it is a valid URL, the mailer will send it as is and let the client handle formatting.

If no runbook is defined the handlers work exactly as they did previously.
