### PR TITLE
Adds redacting mutator extension

### DIFF
--- a/extensions/mutators/redact.rb
+++ b/extensions/mutators/redact.rb
@@ -1,7 +1,7 @@
 # Redacts sensitive event information
 #
-# Requires a Sensu setting snippet 'redact', containing the list of keys 
-# with sensitive values that need redacting, or for clients to have their 
+# Requires a Sensu setting snippet 'redact', containing the list of keys
+# with sensitive values that need redacting, or for clients to have their
 # own redact attribute. If both exist, the client's setting will be preferred.
 # If neither exist, a base set is used.
 #
@@ -14,7 +14,7 @@
 
 module Sensu::Extension
   class Redact < Mutator
-    
+
     def definition
       {
         type: 'extension',
@@ -40,10 +40,10 @@ module Sensu::Extension
       end
       redacted = redact_sensitive(event, keys)
       event = JSON.dump(redacted)
-      yield(event,0)
+      yield(event, 0)
     end
 
-    def redact_sensitive(hash, keys=nil)
+    def redact_sensitive(hash, keys = nil)
       keys ||= %w[
         password passwd pass
         api_key api_token


### PR DESCRIPTION
I've been wanting this feature from Sensu 0.11 for a while, but am not going to run beta software in production, so I created a mutator extension based off of the redaction feature of the upcoming release.

You can configure the keys to redact either through a client attribute `redact` or a setting snipping `redact`. If neither are configured, a basic set of keys is used. If both are set, the client's attribute is preferred.

This is my first time dealing with mutators as well as extensions, so if I'm off the mark anywhere, please let me know!
