### PR TITLE
Mongodb metrics fix

### DIFF
--- a/plugins/mongodb/mongodb-metrics.rb
+++ b/plugins/mongodb/mongodb-metrics.rb
@@ -76,7 +76,7 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
   def gatherReplicationMetrics(serverStatus)
     serverMetrics = {}
     serverMetrics['lock.ratio'] = "#{sprintf("%.5f", serverStatus['globalLock']['ratio'])}" unless serverStatus['globalLock']['ratio'].nil?
-    
+
     serverMetrics['lock.queue.total'] = serverStatus['globalLock']['currentQueue']['total']
     serverMetrics['lock.queue.readers'] = serverStatus['globalLock']['currentQueue']['readers']
     serverMetrics['lock.queue.writers'] = serverStatus['globalLock']['currentQueue']['writers']


### PR DESCRIPTION
When running against hosts using Mongo 2.4.6, the metric would not return values due to an exception being thrown on the line:

``` ruby
serverMetrics['indexes.missRatio'] = "#{sprintf(%.5f", serverStatus['indexCounters']['btree']['missRatio'])}"
```

In at least 2.4.6, there is no key for 'btree' any longer. A statement now checks for this key.
