### PR TITLE
renames Redact extension to 'redact', was still set to 'redaction'

### DIFF
--- a/extensions/mutators/redact.rb
+++ b/extensions/mutators/redact.rb
@@ -18,7 +18,7 @@ module Sensu::Extension
     def definition
       {
         type: 'extension',
-        name: 'redaction',
+        name: 'redact',
       }
     end
 


### PR DESCRIPTION
Forgot to update the name attribute for the extension, this fixes that.
