### PR TITLE
Mongodb autodiscover

### DIFF
--- a/plugins/mongodb/mongodb-metrics.rb
+++ b/plugins/mongodb/mongodb-metrics.rb
@@ -44,32 +44,64 @@ class MongoDB < Sensu::Plugin::Metric::CLI::Graphite
     :short => "-s SCHEME",
     :default => "#{Socket.gethostname}.mongodb"
 
+  option :auto,
+    :description => "Enables automatic discovery of Mongo processes on the host. Requires netstat",
+    :long => "--auto",
+    :short => "-a",
+    :boolean => true,
+    :default => false
+
+  option :naming,
+    :description => "Enables usage of setName under repl to determine a name to append after the scheme. Useful with --auto",
+    :long => "--name",
+    :short => "-n",
+    :boolean => true,
+    :default => false
+
   def run
     host = config[:host]
     port = config[:port]
     db_name = 'admin'
     db_user = config[:user]
     db_password = config[:password]
+    enable_naming = config[:naming]
 
+    begin
+      if config[:auto]
+        `netstat -lnp | grep mongo | grep -o "[0-9.]*:#{port}" | cut -d ':' -f 1`.each do |ip_addr|
+          getMongoStats(ip_addr, port, db_name, db_user, db_password, enable_naming)
+        end 
+      else
+        getMongoStats(host, port, db_name, db_user, db_password, enable_naming)
+      end
+      ok
+    rescue
+      exit(1)
+    end
+  end
+
+  def getMongoStats(host, port, db_name, db_user, db_password, naming_enabled)
     mongo_client = MongoClient.new(host, port)
     @db = mongo_client.db(db_name)
     @db.authenticate(db_user, db_password) unless db_user.nil?
 
     @isMaster = {"isMaster" => 1}
-    begin
-      metrics = {}
-      _result = @db.command(@isMaster)["ok"] == 1
-      serverStatus = @db.command('serverStatus' => 1)
-      if serverStatus["ok"] == 1
-        metrics.update(gatherReplicationMetrics(serverStatus))
-        timestamp = Time.now.to_i
-        metrics.each do |k, v|
+    metrics = {}
+    _result = @db.command(@isMaster)["ok"] == 1
+    serverStatus = @db.command('serverStatus' => 1)
+    if serverStatus["ok"] == 1
+      if naming_enabled
+        serviceName = serverStatus['repl']['setName'].gsub(/rs_p_/, '')
+      end
+      metrics.update(gatherReplicationMetrics(serverStatus))
+      timestamp = Time.now.to_i
+      metrics.each do |k, v|
+        if serviceName == nil
           output [config[:scheme], k].join("."), v, timestamp
+        else
+          output [config[:scheme], serviceName, k].join("."), v, timestamp
         end
       end
-      ok
-    rescue
-      exit(1)
     end
   end
 


### PR DESCRIPTION
Added in the ability for the MongoDB plugin to autodiscover Mongo processes running on the box at the specified port (or 27017 by default). It assumes an identical setup for all the processes on the host (same user/pw, port, etc).
Added in a flag to set an automatic naming option, useful for autodiscovery. It uses the ['repl']['setName'] to get a name to use as part of the scheme. This might not be the best parameter to pull from, but it was unique in the environment I tested on, and matched what I was looking for. 

Both of these are optional flags, and the plugin works the same without.
