### PR TITLE
Add snmp-metrics script

### DIFF
--- a/plugins/snmp/snmp-metrics.rb
+++ b/plugins/snmp/snmp-metrics.rb
@@ -11,7 +11,7 @@
 #
 #   check-snmp -h host -C community -O oid -p prefix -s suffix
 #
-#   Author: Johan van den Dorpe
+#   Copyright (c) 2013 Double Negative Limited
 #   Based on check-snmp.rb by Deepak Mohan Das   <deepakmdass88@gmail.com>
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE


### PR DESCRIPTION
This script allows polling a SNMP OID and sending the data to a metrics handler (i.e. graphite)
