### PR TITLE
Add SMTP authentication to mailer notification handler

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -52,7 +52,7 @@ class Mailer < Sensu::Handler
 
     Mail.defaults do
       delivery_options = {
-        :address    => smtp_addr,
+        :address    => smtp_address,
         :port       => smtp_port,
         :domain     => smtp_domain,
         :openssl_verify_mode => 'none',


### PR DESCRIPTION
This pull requests adds the option for smtp authentication to the mailer.rb notification handler.

mail gem was also updated from 2.4.0 to 2.5.4

Passes rubocop linting
