### PR TITLE
Get the length of a redis list and output it to graphite as a metric.

### DIFF
--- a/plugins/redis/redis-llen-metric.rb
+++ b/plugins/redis/redis-llen-metric.rb
@@ -2,7 +2,7 @@
 #
 # Get the length of a list and push it to graphite
 #
-# 
+#
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.


### PR DESCRIPTION
I use this to graph logstash queues as redis lists are the recommended queuing mechanism for logstash servers. You should be monitoring and graphing them to diagnose problems, this should help you measure your queues. :)
This code is pretty much copied from check redis length and redis graphite plugins, i deserve no credit.
