### PR TITLE
Add option in check-load.rb to divide load averages by cpu/core count

### DIFF
--- a/plugins/system/check-load.rb
+++ b/plugins/system/check-load.rb
@@ -14,11 +14,15 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 
 class LoadAverage
-  def initialize
-    @avg = File.read('/proc/loadavg').split.take(3).map {|a| a.to_f } rescue nil
+  def initialize(per_core = false)
+    @cores = per_core ? cpu_count : 1
+    @avg = File.read('/proc/loadavg').split.take(3).map {|a| (a.to_f / @cores).round(2) } rescue nil
+  end
+  def cpu_count
+    `grep -sc ^processor /proc/cpuinfo`.to_i rescue 0
   end
   def failed?
-    @avg.nil?
+    @avg.nil? || @cores.zero?
   end
   def exceed?(thresholds)
     @avg.zip(thresholds).any? {|a, t| a > t }
@@ -36,6 +40,7 @@ class CheckLoad < Sensu::Plugin::Check::CLI
     :description => 'Load WARNING threshold, 1/5/15 min average',
     :proc => proc {|a| a.split(',').map {|t| t.to_f } },
     :default => [10, 20, 30]
+
   option :crit,
     :short => '-c L1,L5,L15',
     :long => '--crit L1,L5,L15',
@@ -43,8 +48,15 @@ class CheckLoad < Sensu::Plugin::Check::CLI
     :proc => proc {|a| a.split(',').map {|t| t.to_f } },
     :default => [25, 50, 75]
 
+  option :per_core,
+    :short => '-p',
+    :long => '--per-core',
+    :description => 'Divide load average results by cpu/core count',
+    :boolean => 'true',
+    :default => false
+
   def run
-    avg = LoadAverage.new
+    avg = LoadAverage.new(config[:per_core])
     warning "Could not read load average from /proc" if avg.failed?
     message "Load average: #{avg}"
     critical if avg.exceed?(config[:crit])


### PR DESCRIPTION
Using `--per-core` option will divide system load averages by the number of cpus (cores/hyperthreads) the system believes it has. Allows the ability to specify uniform warning/critical thresholds across machines of varying cpu/core counts.

For example, a 1.0 load using this option assumes the system is at 100% capacity regardless of whether it is a single vcpu virtual machine or a multi-cpu, multi-core server with hyperthreading.
