### PR TITLE
Update vmstat-metrics.rb to output in Bytes instead of Kb

### DIFF
--- a/plugins/system/vmstat-metrics.rb
+++ b/plugins/system/vmstat-metrics.rb
@@ -36,7 +36,7 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    result = convert_integers(`vmstat 1 2|tail -n1`.split(" "))
+    result = convert_integers(`vmstat -S B 1 2|tail -n1`.split(" "))
     timestamp = Time.now.to_i
     metrics = {
       :procs => {


### PR DESCRIPTION
With this change a vmstat graph in graphite will show "180 M" on the Y axis value instead of "18000.0 K".
