### PR TITLE
Added option to specify encoding page for check-log.rb 

### DIFF
--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -119,7 +119,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
 
   def open_log(log_file)
     state_dir = config[:state_auto] || config[:state_dir]
-    
+
     # Opens file using optional encoding page.  ex: 'iso8859-1'
     if config[:encoding]
       @log = File.open(log_file, "r:#{config[:encoding]}")


### PR DESCRIPTION
This provides a method for a user to explicitly open log file with a specific encoding.  If no encoding passed to command, then it opens file normally, without specifying encoding.

Example:
check-log.rb -f /var/log/testing.log -s /tmp -q 'This is a test String' -e 'r:iso8859-1'

http://stackoverflow.com/a/15507882
## 

jake herbst
jmherbst@gmail.com
