### PR TITLE
Changes to comply with more xmpp server implementations:

### DIFF
--- a/handlers/notification/xmpp.rb
+++ b/handlers/notification/xmpp.rb
@@ -33,7 +33,7 @@ class XmppHandler < Sensu::Handler
     cl = Client.new(jid)
     cl.connect(xmpp_server)
     cl.auth(xmpp_password)
-    cl.send(Jabber::Presence::new.set_type(:available))
+    cl.send(Jabber::Presence.new.set_type(:available))
     if xmpp_target_type == 'conference'
       m = Message.new(xmpp_target, body)
       room = MUC::MUCClient.new(cl)


### PR DESCRIPTION
Without the first change, on at least 2 jabber servers I've tried (jabberd and OS X builtin) the handler joins the room, but no messages appear.

Without the second change a random nick is appended to the jid (xmpp_jid) when the user joins/leaves the room - e.g.:

```
sensu [sensu@foo.example.com/928793f28fc90ec46c85ea0e9a309fd0917ea2e2] entered the room.
```

After the patch:

```
sensu [sensu@foo.example.com] entered the room.
```
