### PR TITLE
check-disk-health: Check only disks

### DIFF
--- a/plugins/system/check-disk-health.sh
+++ b/plugins/system/check-disk-health.sh
@@ -10,7 +10,7 @@
 
 
 # get devices (capture /dev/sd* and /dev/hd*)
-DEVICES=$( lsblk | awk '/^[sh]/ {print $1}' )
+DEVICES=$( lsblk | awk '/ disk *$/ {print $1}' )
 # store fails
 FAILS=()
 


### PR DESCRIPTION
Suppose we have these devices:

```
NAME   MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
sda      8:0    0 931.5G  0 disk
├─sda1   8:1    0 914.4G  0 part /
├─sda2   8:2    0     1K  0 part
└─sda5   8:5    0  17.1G  0 part [SWAP]
sr0     11:0    1  1024M  0 rom
```

The previous implementation captures sda and also sr0, which is not a disk. This patch fixes it.
