### PR TITLE
Add option to check-http for printing part of res.body

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -37,6 +37,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   option :timeout, :short => '-t SECS', :proc => proc { |a| a.to_i }, :default => 15
   option :redirectok, :short => '-r', :boolean => true, :default => false
   option :redirectto, :short => '-R URL'
+  option :response_bytes, :long => '--response-bytes BYTES', :proc => proc { |a| a.to_i }
 
   def run
     if config[:url]
@@ -93,37 +94,43 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
     end
     res = http.request(req)
 
+    if config[:response_bytes]
+      body = "\n" + res.body[1..config[:response_bytes].to_i]
+    else
+      body = ''
+    end
+
     case res.code
     when /^2/
       if config[:redirectto]
-        critical "expected redirect to #{config[:redirectto]} but got #{res.code}"
+        critical "expected redirect to #{config[:redirectto]} but got #{res.code}" + body
       elsif config[:pattern]
         if res.body =~ /#{config[:pattern]}/
-          ok "#{res.code}, found /#{config[:pattern]}/ in #{res.body.size} bytes"
+          ok "#{res.code}, found /#{config[:pattern]}/ in #{res.body.size} bytes" + body
         else
           critical "#{res.code}, did not find /#{config[:pattern]}/ in #{res.body.size} bytes: #{res.body[0...200]}..."
         end
       else
-        ok "#{res.code}, #{res.body.size} bytes"
+        ok "#{res.code}, #{res.body.size} bytes" + body
       end
     when /^3/
       if config[:redirectok] || config[:redirectto]
         if config[:redirectok]
-          ok "#{res.code}, #{res.body.size} bytes"
+          ok "#{res.code}, #{res.body.size} bytes" + body
         elsif config[:redirectto]
           if config[:redirectto] == res['Location']
-            ok "#{res.code} found redirect to #{res['Location']}"
+            ok "#{res.code} found redirect to #{res['Location']}" + body
           else
-            critical "expected redirect to #{config[:redirectto]} instead redirected to #{res['Location']}"
+            critical "expected redirect to #{config[:redirectto]} instead redirected to #{res['Location']}" + body
           end
         end
       else
-        warning res.code
+        warning res.code + body
       end
     when /^4/, /^5/
-      critical res.code
+      critical res.code + body
     else
-      warning res.code
+      warning res.code + body
     end
   end
 end


### PR DESCRIPTION
A new option to display a chosen number of bytes of data returned in the HTTP response body. Default behaviour is OFF.

Use Case: you have a /healthcheck endpoint that returns certain information which is useful to know via the Sensu dashboard/api rather than digging into further tools/logs to see why a 4XX or 5XX occurred. Saves valuable time when investigating alerts.

Added to all responses for consistency.
