### PR TITLE
Don't force ruby 1.9 in check-load

### DIFF
--- a/plugins/system/check-load.rb
+++ b/plugins/system/check-load.rb
@@ -17,7 +17,7 @@ if RUBY_VERSION < '1.9.0'
 
   # round(n) doesn't exist in ruby < 1.9
   class Float
-    alias oldround:round
+    alias_method :oldround, :round
       def round(precision = nil)
           if precision.nil?
               return self


### PR DESCRIPTION
The round(n) method is new in ruby 1.9 therefore the update @ea42244 forces a user of `check-load.rb` to be on at least 1.9. This PR adds an alias to ensure the correct behaviour is observed with version < 1.9 whilst maintaining the functionality of the aforementioned commit.
