### PR TITLE
[ec2_node] Updates handler to also filter stopped instances

### DIFF
--- a/handlers/other/ec2_node.rb
+++ b/handlers/other/ec2_node.rb
@@ -1,6 +1,26 @@
 #!/usr/bin/env ruby
 #
-# This handler deletes a Sensu client if it's been stopped or terminated in EC2
+# CHANGELOG:
+# * 0.4.0:
+#   - Adds ability to specify a list of states an individual client can have in
+#     EC2. If none is specified, it filters out 'terminated' and 'stopped'
+#     instances by default.
+#   - Updates how we are "puts"-ing to the log.
+# * 0.3.0:
+#   - Updates handler to additionally filter stopped instances.
+# * 0.2.1:
+#   - Updates requested configuration snippets so they'll be redacted by
+#     default.
+# * 0.2.0:
+#   - Renames handler from chef_ec2_node to ec2_node
+#   - Removes Chef-related stuff from handler
+#   - Updates documentation
+# * 0.1.0:
+#   - Initial release
+#
+# This handler deletes a Sensu client if it's been stopped or terminated in EC2.
+# Optionally, you may specify a client attribute `ec2_states`, a list of valid
+# states an instance may have.
 #
 # NOTE: The implementation for correlating Sensu clients to EC2 instances may
 # need to be modified to fit your organization. The current implementation
@@ -83,7 +103,7 @@ class Ec2Node < Sensu::Handler
     unless ec2_node_exists?
       delete_sensu_client!
     else
-      puts "EC2 Node - #{@event['client']['name']} appears to exist in EC2"
+      puts "[EC2 Node] #{@event['client']['name']} appears to exist in EC2"
     end
   end
 
@@ -93,8 +113,9 @@ class Ec2Node < Sensu::Handler
   end
 
   def ec2_node_exists?
-    running_instances = ec2.servers.select { |s| s.state == 'running' }
-    instance_ids = running_instances.collect { |s| s.id }
+    states = get_valid_states
+    filtered_instances = ec2.servers.select { |s| states.include?(s.state) }
+    instance_ids = filtered_instances.collect { |s| s.id }
     instance_ids.each do |id|
       return true if id == @event['client']['name']
     end
@@ -118,13 +139,21 @@ class Ec2Node < Sensu::Handler
   def deletion_status(code)
     case code
     when '202'
-      puts "EC2 Node - [202] Successfully deleted Sensu client: #{node}"
+      puts "[EC2 Node] 202: Successfully deleted Sensu client: #{node}"
     when '404'
-      puts "EC2 Node - [404] Unable to delete #{node}, doesn't exist!"
+      puts "[EC2 Node] 404: Unable to delete #{node}, doesn't exist!"
     when '500'
-      puts "EC2 Node - [500] Miscellaneous error when deleting #{node}"
+      puts "[EC2 Node] 500: Miscellaneous error when deleting #{node}"
     else
-      puts "EC2 Node - [#{res}] Completely unsure of what happened!"
+      puts "[EC2 Node] #{res}: Completely unsure of what happened!"
+    end
+  end
+
+  def get_valid_states
+    if @event['client'].has_key?('ec2_states')
+      return @event['client']['ec2_states']
+    else
+      return ['running']
     end
   end
 


### PR DESCRIPTION
We ran into the issue where instances which were stopped in EC2 were polluting the dashboard and causing unnecessary work for the sensu server. This handler now deletes a sensu-client if it isn't running in EC2, meaning stopped or terminated.
