### PR TITLE
Rescue `no route to host` errors for check-banner plugin

### DIFF
--- a/plugins/network/check-banner.rb
+++ b/plugins/network/check-banner.rb
@@ -59,6 +59,8 @@ class CheckBanner < Sensu::Plugin::Check::CLI
       critical "Connection refused by #{config[:host]}:#{config[:port]}"
     rescue Timeout::Error
       critical "Connection or read timed out"
+    rescue Errno::EHOSTUNREACH
+      critical "Check failed to run: No route to host"
     end
   end
 


### PR DESCRIPTION
Rescues an additional error for this plugin to keep the chat channel a little less messy when things break.

Before:

my-sensu-server.tld/a-banner-host-check: CheckBanner CRITICAL: Check failed to run: No route to host - connect(2), /etc/sensu/plugins/check-banner.rb:53:in `initialize'/etc/sensu/plugins/check-banner.rb:53:in`new'/etc/sensu/plugins/check-banner.rb:53:in `get_banner'/etc/sensu/plugins/check-banner.rb:66:in`run'/usr/lib/ruby/gems/1.8/gems/sensu-plugin-0.1.7/lib/sensu-plugin/cli.rb:56/etc/sensu/plugins/check-banner.rb:65

After:

my-sensu-server.tld/a-banner-host-check: CheckBanner CRITICAL: Check failed to run: No route to host
