### PR TITLE
If we can't get data from graphite, return UNKNOWN rather than CRITICAL

### DIFF
--- a/plugins/graphite/check-data.rb
+++ b/plugins/graphite/check-data.rb
@@ -113,7 +113,7 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
   # Check the age of the data being processed
   def check_age
     if (Time.now.to_i - @end) > config[:allowed_graphite_age]
-      critical "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
+      unknown "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
     end
   end
 
@@ -143,9 +143,9 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
         @step = ((@end - @start) / @raw_data['datapoints'].size.to_f).ceil
         nil
       rescue OpenURI::HTTPError
-        critical "Failed to connect to graphite server"
+        unknown "Failed to connect to graphite server"
       rescue NoMethodError
-        critical "No data for time period and/or target"
+        unknown "No data for time period and/or target"
       end
     end
   end


### PR DESCRIPTION
The graphite check-data.rb plugin will raise a CRITICAL error if it can't contact the graphite server, or if the required data can't be obtained somehow.

I don't think this is appropriate - when I define a check based on graphite data, it's for a specific problem we want to know about. The only case where I want the check to raise critical is when value falls outside what's defined in the check. If graphite isn't working, or the data collection isn't working, that's a different issue entirely.

We run a monitoring pipeline where we try and collect data, store it in graphite, and then alert off the data stored in graphite. So we use this check heavily. This means that if graphite is down, then we get lots of CRITICAL failing checks.

Instead I'd rather see the check reporting there's a problem, and we can define specific checks to make sure graphite or the collection agents are working.
