### PR TITLE
metrics-net: Skip if /sys/class/net/:iface_path is a regular file

### DIFF
--- a/plugins/network/metrics-net.rb
+++ b/plugins/network/metrics-net.rb
@@ -49,6 +49,7 @@ class LinuxPacketMetrics < Sensu::Plugin::Metric::CLI::Graphite
     timestamp = Time.now.to_i
 
     Dir.glob('/sys/class/net/*').each do |iface_path|
+      next if File.file?(iface_path)
       iface = File.basename(iface_path)
       next if iface == 'lo'
 


### PR DESCRIPTION
If the host has a bond interface, there would be `/sys/class/net/bonding_masters`, which is not a directory. In this case, `metrics-net.rb` fails to run and results in an error:

```
Check failed to run: Not a directory - /sys/class/net/bonding_masters/statistics/tx_packets, ["/etc/sensu/plugins/sensu-community-plugins/network/metrics-net.rb:55:in `initialize'", "/etc/sensu/plugins/sensu-community-plugins/network/metrics-net.rb:55:in `open'", "/etc/sensu/plugins/sensu-community-plugins/network/metrics-net.rb:55:in `block in run'", "/etc/sensu/plugins/sensu-community-plugins/network/metrics-net.rb:51:in `each'", "/etc/sensu/plugins/sensu-community-plugins/network/metrics-net.rb:51:in `run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-0.2.1/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

 With this patch, it simply skips if the `iface_path` is a regular file.
