### PR TITLE
Fixed the getopts with check-swap-percentage.sh

### DIFF
--- a/plugins/system/check-swap-percentage.sh
+++ b/plugins/system/check-swap-percentage.sh
@@ -24,6 +24,7 @@ CRIT=${CRIT:=100}
 # get swap details
 USED=`free -m | grep 'Swap:' | awk '{ print $3 }'`
 TOTAL=`free -m | grep 'Swap:' | awk '{ print $2 }'`
+PERCENT=`echo "scale=3;$USED/$TOTAL*100" | bc -l | awk '{printf "%f", $0}'`
 
 if [[ $TOTAL -eq 0 ]] ; then
   echo "There is no SWAP on this machine"


### PR DESCRIPTION
It seems that it only took the "-w" option with the original setup.
Adding the two ":" to the getopts line allows you now to leverage
both -c and -w or just one of them.

Also added a check for a way to end the script with 0 SWAP.
