### PR TITLE
Time out TCPSocket.new As Well

### DIFF
--- a/plugins/network/check-banner.rb
+++ b/plugins/network/check-banner.rb
@@ -50,8 +50,8 @@ class CheckBanner < Sensu::Plugin::Check::CLI
 
   def get_banner
     begin
-      sock = TCPSocket.new(config[:host], config[:port])
       timeout(config[:timeout]) do
+        sock = TCPSocket.new(config[:host], config[:port])
         sock.puts config[:write] if config[:write]
         sock.readline
       end


### PR DESCRIPTION
We probably want TCPSocket.new to be timed out too, in case the destination server is slow accepting new connections.
