### PR TITLE
Fix cpu checks for older Linux kernels

### DIFF
--- a/plugins/system/check-cpu.rb
+++ b/plugins/system/check-cpu.rb
@@ -46,14 +46,14 @@ class CheckCPU < Sensu::Plugin::Check::CLI
     sleep config[:sleep]
     cpu_stats_after = get_cpu_stats
 
+    # Some kernels don't have a 'guest' value (RHEL5).
+    metrics = metrics.slice(0, cpu_stats_after.length)
+
     cpu_total_diff = 0.to_f
     cpu_stats_diff = []
     metrics.each_index do |i|
-      # Some OS's don't have a 'guest' values (RHEL)
-      unless cpu_stats_after[i].nil?
-        cpu_stats_diff[i] = cpu_stats_after[i] - cpu_stats_before[i]
-        cpu_total_diff += cpu_stats_diff[i]
-      end
+      cpu_stats_diff[i] = cpu_stats_after[i] - cpu_stats_before[i]
+      cpu_total_diff += cpu_stats_diff[i]
     end
 
     cpu_stats = []

--- a/plugins/system/cpu-pcnt-usage-metrics.rb
+++ b/plugins/system/cpu-pcnt-usage-metrics.rb
@@ -22,7 +22,8 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
       # we are matching TOTAL stats and returning a hash of values
       if name.match(/^cpu$/)
         # return the CPU metrics sample as a hash
-        return Hash[cpu_metrics.zip(info.map(&:to_i))]
+        # filter out nil values, as some kernels don't have a 'guest' value
+        return Hash[cpu_metrics.zip(info.map(&:to_i))].reject {|key, value| value == nil }
       end
     end
   end
@@ -32,10 +33,10 @@ class CpuGraphite < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    cpu_metrics = ['user', 'nice', 'system', 'idle', 'iowait', 'irq', 'softirq', 'steal', 'guest']
     cpu_sample1 = get_proc_stats
     sleep(1)
     cpu_sample2 = get_proc_stats
+    cpu_metrics = cpu_sample2.keys
 
     # we will sum all jiffy counts read in get_proc_stats
     cpu_total1 = sum_cpu_metrics(cpu_sample1)


### PR DESCRIPTION
Older Linux kernels don't have the "guest" field in `/proc/stat`.  While `check-cpu.rb` claimed to accommodate that, it didn't actually work all the way through.  Fix that, and also fix `cpu-pcnt-usage-metrics.rb`, which didn't know about this at all.
