### PR TITLE
Add DHCP server check.

### DIFF
--- a/plugins/dhcp/check-dhcp.rb
+++ b/plugins/dhcp/check-dhcp.rb
@@ -57,7 +57,6 @@ class CheckDHCP < Sensu::Plugin::Check::CLI
     :short => '-i IPADDR',
     :long => '--ipaddr IPADDR'
 
-
   def dhcp_discover
 
     request = DHCP::Discover.new


### PR DESCRIPTION
A check to send a DHCPDISCOVER message to a server, and look for valid responses.  Optionally, check that the response is a DHCPOFFER, and compare the IP address offered with one provided.

First attempt at a sensu plugin, so please let me know if there are any glaring errors!
