### PR TITLE
Add warning state and summary validation to flapjack extension.

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -50,14 +50,15 @@ module Sensu::Extension
     def run(event)
       event = Oj.load(event)
       state = event[:check][:status]
-      if state == 0
-        check_state = "ok"
-      elsif state == 1
-        check_state = "warning"
-      elsif state == 2
-        check_state = "critical"
+      check_state = case state
+      when 0
+        'ok'
+      when 1
+        'warning'
+      when 2
+        'critical'
       else
-        check_state = "unknown"
+        'unknown'
       end
       timestamp = event[:check][:issued]
       entity = event[:client][:name]


### PR DESCRIPTION
Ensures checks in a warning state are placed into the correct state in flapjack. Always converts summary to string before sending to flapjack.
