### PR TITLE
Fix rainbow issue - lock it until update of rubocop

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,10 @@
 source 'https://rubygems.org'
 
-gem 'sensu-plugin'
+ruby '2.0.0'
 
+gem 'sensu-plugin'
+#TODO: drop rainbow after updating rubocop to 1.18 ish
+gem 'rainbow', '~> 1.99.2'
 group :test do
   gem 'rubocop', '~> 0.8.2'
   gem 'rspec'


### PR DESCRIPTION
Rainbow is a ANSI colorization gem (yes, another one). It breaks travis as it rubocop had non strict version
requirements, which leads to such a thing.
