### PR TITLE
round(n) doesn't exist in ruby < 1.9

### DIFF
--- a/plugins/system/check-cpu.rb
+++ b/plugins/system/check-cpu.rb
@@ -3,7 +3,20 @@
 # Check CPU Plugin
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
+if RUBY_VERSION < '1.9.0'
+  require 'rubygems'
+  # round(n) doesn't exist in ruby < 1.9
+  class Float
+    alias_method :oldround, :round
+      def round(precision = nil)
+          if precision.nil?
+            return self
+          else
+            return ((self * 10**precision).oldround.to_f) / (10**precision)
+          end
+      end
+  end
+end
 require 'sensu-plugin/check/cli'
 
 class CheckCPU < Sensu::Plugin::Check::CLI


### PR DESCRIPTION
Round(n) doesn't exist in ruby < 1.9 so to make that work with older ruby version we need to modify the round method.
