### PR TITLE
Replaced 'Sensu Alert' title with 'event_name'

### DIFF
--- a/handlers/notification/pushover.rb
+++ b/handlers/notification/pushover.rb
@@ -24,10 +24,10 @@ class Pushover < Sensu::Handler
     apiurl = settings['pushover']['apiurl'] || 'https://api.pushover.net/1/messages'
 
     params = {
-      :title => "Sensu Alert",
+      :title => event_name,
       :user => settings['pushover']['userkey'],
       :token => settings['pushover']['token'],
-      :message => "#{event_name}: #{@event['check']['output']}",
+      :message => @event['check']['output']
     }
 
     begin


### PR DESCRIPTION
I moved the event_name to the pushover title field to prevent cut off check output in the message field (happens for long host names for example)
