### PR TITLE
Accept boolean key-value checks

### DIFF
--- a/plugins/http/check-http-json.rb
+++ b/plugins/http/check-http-json.rb
@@ -103,7 +103,15 @@ class CheckJson < Sensu::Plugin::Check::CLI
       if json_valid?(res.body)
         if (config[:key] != nil and config[:value] != nil)
           json = JSON.parse(res.body)
-          if json[config[:key]] == config[:value]
+          case json[config[:key]]
+            when TrueClass 
+              config_value = config[:value] == "true"
+            when FalseClass
+              config_value = config[:value] == "false" ? false : true
+            else
+              config_value = config[:value]
+          end
+          if json[config[:key]] == config_value
             ok "Valid JSON and key present and correct"
           else
             critical "JSON key check failed"


### PR DESCRIPTION
When the value of the --key KEY to check in the json response is a boolean (like {"success": true}) the input value --value is now converted to a boolean to accept boolean key-value checks.
