### PR TITLE
check-beanstalkd: Fixes the types of W,C arguments.

### DIFF
--- a/plugins/beanstalkd/check-beanstalkd.rb
+++ b/plugins/beanstalkd/check-beanstalkd.rb
@@ -56,18 +56,21 @@ class BeanstalkdQueuesStatus < Sensu::Plugin::Check::CLI
     description: 'ready tasks WARNING/CRITICAL thresholds',
     short:       '-r W,C',
     long:        '--ready-tasks W,C',
+    proc:        proc { |a| a.split(',', 2).map(&:to_i) },
     default:     [6000, 8000]
 
   option :urgent,
     description: 'urgent tasks WARNING/CRITICAL thresholds',
     short:       '-u W,C',
     long:        '--urgent-tasks W,C',
+    proc:        proc { |a| a.split(',', 2).map(&:to_i) },
     default:     [2000, 3000]
 
   option :buried,
     description: 'buried tasks WARNING/CRITICAL thresholds',
     short:       '-b W,C',
     long:        '--buried-tasks W,C',
+    proc:        proc { |a| a.split(',', 2).map(&:to_i) },
     default:     [30, 60]
 
   def get_beanstalkd_connection


### PR DESCRIPTION
Unless the default was used, the argument would be a string instead of a tuple
of numbers which wouldn't be comparable to a Fixnum lower in the code.
