### PR TITLE
check-procs.rb: Reasonable matching conditions

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -210,17 +210,15 @@ class CheckProcs < Sensu::Plugin::Check::CLI
 
     if !!config[:crit_under] && count < config[:crit_under]
       critical msg
-    end
-    if !!config[:crit_over] && count > config[:crit_over]
+    elsif !!config[:crit_over] && count > config[:crit_over]
       critical msg
-    end
-    if !!config[:warn_under] && count < config[:warn_under]
+    elsif !!config[:warn_under] && count < config[:warn_under]
       warning msg
-    end
-    if !!config[:warn_over] && count > config[:warn_over]
+    elsif !!config[:warn_over] && count > config[:warn_over]
       warning msg
+    else
+      ok msg
     end
-    ok msg
   end
 
 end


### PR DESCRIPTION
The current `check-procs.rb` behavior is quite confusing. Suppose we have 9 ssh processes running and any processes don't mach to 'foo', then we get the following results which don't make sense to me:

```
% ./plugins/processes/check-procs.rb -p ssh              # Why not OK?
CheckProcs CRITICAL: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p ssh -w 5 -c 10
CheckProcs WARNING: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p ssh -W 1 -w 10   # Why not OK?
CheckProcs CRITICAL: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p foo              # Why not CRITICAL?
CheckProcs OK: Found 0 matching processes; cmd /foo/
% ./plugins/processes/check-procs.rb -p foo -C 0         # Why not WARNING?
CheckProcs OK: Found 0 matching processes; cmd /foo/
% ./plugins/processes/check-procs.rb -p foo -W 0 -C 0
CheckProcs OK: Found 0 matching processes; cmd /foo/
```

I think `check-procs.rb` should check if any matching processes exist when no thresholds are specified. With this patch, we'll get this:

```
% ./plugins/processes/check-procs.rb -p ssh
CheckProcs OK: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p ssh -w 5 -c 10
CheckProcs WARNING: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p ssh -W 1 -w 10
CheckProcs OK: Found 9 matching processes; cmd /ssh/
% ./plugins/processes/check-procs.rb -p foo
CheckProcs CRITICAL: Found 0 matching processes; cmd /foo/
% ./plugins/processes/check-procs.rb -p foo -C 0
CheckProcs WARNING: Found 0 matching processes; cmd /foo/
% ./plugins/processes/check-procs.rb -p foo -W 0 -C 0
CheckProcs OK: Found 0 matching processes; cmd /foo/
```
