### PR TITLE
Added require rubygems < 1.9 for graphite mutator

### DIFF
--- a/mutators/graphite.rb
+++ b/mutators/graphite.rb
@@ -25,7 +25,7 @@
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
-
+require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'json'
 
 # parse event


### PR DESCRIPTION
Need to require rubygems gem for ruby <1.9 . 
