### PR TITLE
Added an option to allow users to set the comparison operator

### DIFF
--- a/plugins/snmp/check-snmp.rb
+++ b/plugins/snmp/check-snmp.rb
@@ -56,7 +56,7 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
 
   option :comparison,
     :short => '-o comparison operator',
-    :description => 'Operator used to compare data with warning/critial values. Can be set to "le" (<=), "ge" (>=). if data <comparision> critical/warning, raise alert.',
+    :description => 'Operator used to compare data with warning/critial values. Can be set to "le" (<=), "ge" (>=).',
     :default => 'ge'
 
   def run


### PR DESCRIPTION
They are now able to raise alert is some data is lower than the warning/critical threshold. Previous to that modification, only data higher than the warning/critical threshold were able to raise alerts.

The default option remains >=.
