### PR TITLE
ntpstats-metrics.rb: Fix uninitialized constant NtpStatsMetrics::Socket

### DIFF
--- a/plugins/system/ntpstats-metrics.rb
+++ b/plugins/system/ntpstats-metrics.rb
@@ -10,6 +10,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
+require 'socket'
 
 class NtpStatsMetrics < Sensu::Plugin::Metric::CLI::Graphite
 


### PR DESCRIPTION
With the embedded ruby, ntpstats-metrics.rb fails due to a `NameError` like this:

```
Sensu::Plugin::CLI: ["Not implemented! You should override Sensu::Plugin::CLI#run."]
./plugins/system/ntpstats-metrics.rb:26:in `<class:NtpStatsMetrics>': uninitialized constant NtpStatsMetrics::So
cket (NameError)
        from ./plugins/system/ntpstats-metrics.rb:14:in `<main>'
```

This patch fixes the issue by requiring `socket` module explicitly.
