### PR TITLE
"Fix hipchat handler for sensu 0.12.3"

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -14,7 +14,7 @@ class HipChatNotif < Sensu::Handler
   def handle
     settings_hipchat = settings["handlers"]
     apiversion = settings_hipchat["hipchat"]["apiversion"] || 'v1'
-    hipchatmsg = HipChat::Client.new(settings_hipchat["hipchat"]["apikey"], :api_version => apiversion))
+    hipchatmsg = HipChat::Client.new(settings_hipchat["hipchat"]["apikey"], :api_version => apiversion)
     room = settings_hipchat["hipchat"]["room"]
     from = settings_hipchat["hipchat"]["from"] || 'Sensu'
 


### PR DESCRIPTION
If I use clean hipchat handler I has error:

```
"output":"/etc/sensu/handlers/hipchat.rb:15:in `handle': undefined method `[]' for nil:NilClass (NoMethodError)\n"}
```

It was because settings not contain 'hipchat' options, only ["handlers"]["hipchat"]
just quick fix. I am newby in sensu, and sorry if I miss something. That fix work for me. 
