### PR TITLE
Corrected the parsing of the use_ami_role setting from sns.json.

### DIFF
--- a/handlers/notification/sns.rb
+++ b/handlers/notification/sns.rb
@@ -31,7 +31,8 @@ class SnsNotifier < Sensu::Handler
   end
 
   def useAmiRole
-    settings['sns']['use_ami_role'] || true
+    use_ami_role = settings['sns']['use_ami_role']
+    use_ami_role.nil? ? true : use_ami_role
   end
 
   def awsAccessKey


### PR DESCRIPTION
This statement
  settings['sns']['use_ami_role'] || true
doesn't work for {"use_ami_role":false} because false || true == true.
As a result, useAmiRole would always return true no matter what the setting was in sns.json.
Introduced a nil check instead.
