### PR TITLE
Created a system_profile extension, /proc/* metrics

### DIFF
--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -1,3 +1,23 @@
+# System Profile (metrics)
+# ===
+#
+# Collects a variety of system metrics every 10 seconds (by default).
+# Expects a "graphite" handler on the Sensu server, eg:
+#
+# "graphite": {
+#   "type": "tcp",
+#   "socket": {
+#     "host": "graphite.hw-ops.com",
+#     "port": 2003
+#   },
+#   "mutator": "only_check_output"
+# }
+#
+# Copyright 2014 Heavy Water Operations, LLC.
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
 module Sensu
   module Extension
     class SystemProfile < Check


### PR DESCRIPTION
Idea:
- Create a TCP handler for Graphite plain-text (2003)
- Drop this extension into /etc/sensu/extensions & restart clients
- Go!
