### PR TITLE
Eliminate Travis confusion about ruby versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
 source 'https://rubygems.org'
 
-ruby '2.1.0'
-
 gem 'sensu-plugin'
 
 group :test do


### PR DESCRIPTION
Travis somehow confused about Gemfile specified ruby version.
