### PR TITLE
make ceph-osd-metrics use sensu/io, tiny improvements

### DIFF
--- a/plugins/ceph/ceph-osd-metrics.rb
+++ b/plugins/ceph/ceph-osd-metrics.rb
@@ -26,7 +26,6 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
 require 'sensu/io'
 require 'json'
-require 'English'
 
 class CephOsdMetrics < Sensu::Plugin::Metric::CLI::Graphite
 


### PR DESCRIPTION
...this also introduces the possiblity of setting a timeout.  Besides
that, this change adds a warning if the `Dir.glob` fails to match anything and
a tiny change in the way the `osd_number` is extracted from the socket
path.
