### PR TITLE
Update check-procs plugin.

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -130,7 +130,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
 
   def read_pid(path)
     if File.exists?(path)
-      File.read(path).chomp.to_i
+      File.read(path).strip.to_i
     else
       unknown "Could not read pid file #{path}"
     end
@@ -177,7 +177,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
   def run
     procs = get_procs
 
-    if (config[:file_pid] && (file_pid = read_pid(config[:file_pid])))
+    if config[:file_pid] && (file_pid = read_pid(config[:file_pid]))
       procs.reject! { |p| p[:pid].to_i != file_pid }
     end
     procs.reject! {|p| p[:pid].to_i == $$ } unless config[:match_self]


### PR DESCRIPTION
- Convert `read_pid` class method to instance method and use it inside
  `#run` instead of call it during the parsing of options. There was a
  "stack level" too deep" with the old way if you specify an unexisting
  pidfile path.
  
  Ex:
  
  ```
  ruby check-procs.rb -f unknown_file.unknown_ext
  Check failed to run: stack level too deep, ["/var/lib/gems/1.9.1/gems/mixlib-cli-1.4.0/lib/mixlib/cli.rb:162"]
  /var/lib/gems/1.9.1/gems/sensu-plugin-0.2.2/lib/sensu-plugin/cli.rb:63:in `block in <class:CLI>': undefined method `warning' for nil:NilClass (NoMethodError)
  ```
- Update `read_pid` method to check if file with pid exists instead of
  rescue the exception directly.
  
  Exception flow is not a good practice and the performance is very poor.
  There is an example in: https://gist.github.com/areina/9233841
