### PR TITLE
accommodate non-string key/value

### DIFF
--- a/plugins/http/check-http-json.rb
+++ b/plugins/http/check-http-json.rb
@@ -103,7 +103,7 @@ class CheckJson < Sensu::Plugin::Check::CLI
       if json_valid?(res.body)
         if (config[:key] != nil && config[:value] != nil)
           json = JSON.parse(res.body)
-          if json[config[:key]] == config[:value]
+          if json[config[:key]].to_s == config[:value].to_s
             ok "Valid JSON and key present and correct"
           else
             critical "JSON key check failed"


### PR DESCRIPTION
I am having more success when booleans, and possibly numbers, would be converted to string before comparison.
