### PR TITLE
noauto option mountpoints should be ignored

### DIFF
--- a/plugins/system/check-fstab-mounts.rb
+++ b/plugins/system/check-fstab-mounts.rb
@@ -35,7 +35,7 @@ class CheckFstabMounts < Sensu::Plugin::Check::CLI
     @fstab.each do |line|
       next if line =~ /^\s*#/
       fields = line.split(/\s+/)
-      next if fields[1] == 'none'
+      next if fields[1] == 'none' || (fields[3].include? 'noauto')
       next if config[:fstypes] && !config[:fstypes].include?(fields[2])
       if @proc_mounts.select {|m| m.split(/\s+/)[1] == fields[1]}.empty?
         @missing_mounts << fields[1]


### PR DESCRIPTION
Mount Points with the noauto option specified are not expected to be mounted, and not mounted by the system at boot time. They are mostly temporarily mounted when needed, listed in /etc/fstab only for convenience, and highly unlikely to be serving critical data on server systems.
