### PR TITLE
swap type needs enhanced logic

### DIFF
--- a/plugins/system/check-fstab-mounts.rb
+++ b/plugins/system/check-fstab-mounts.rb
@@ -14,6 +14,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
+require 'pathname'
 
 class CheckFstabMounts < Sensu::Plugin::Check::CLI
   option :fstypes,
@@ -27,6 +28,7 @@ class CheckFstabMounts < Sensu::Plugin::Check::CLI
     super
     @fstab = IO.readlines '/etc/fstab'
     @proc_mounts = IO.readlines '/proc/mounts'
+    @swap_mounts = IO.readlines '/proc/swaps'
     @missing_mounts = []
   end
 
@@ -37,8 +39,14 @@ class CheckFstabMounts < Sensu::Plugin::Check::CLI
       fields = line.split(/\s+/)
       next if fields[1] == 'none'
       next if config[:fstypes] && !config[:fstypes].include?(fields[2])
-      if @proc_mounts.select {|m| m.split(/\s+/)[1] == fields[1]}.empty?
-        @missing_mounts << fields[1]
+      if fields[2] != 'swap'
+        if @proc_mounts.select {|m| m.split(/\s+/)[1] == fields[1]}.empty?
+          @missing_mounts << fields[1]
+        end
+      else
+        if @swap_mounts.select {|m| m.split(/\s+/)[0] == Pathname.new(fields[0]).realpath.to_s}.empty?
+          @missing_mounts << fields[1]
+        end
       end
     end
   end


### PR DESCRIPTION
The script in its present state cannot determine about validity of swap mounts and hence reports an error every time about type swap partitions listed in /etc/fstab. swap type partitions are supposed to be defined in /etc/fstab .
