### PR TITLE
Opsgenie heartbeat check: configurable source

### DIFF
--- a/plugins/opsgenie/opsgenie-heartbeat.rb
+++ b/plugins/opsgenie/opsgenie-heartbeat.rb
@@ -14,22 +14,22 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require "net/https"
-require "uri"
-require "json"
+require 'net/https'
+require 'uri'
+require 'json'
 
 class OpsgenieHeartbeat < Sensu::Plugin::Check::CLI
 
   option :api_key,
-    :short => "-k apiKey",
-    :long => "--key apiKey",
-    :description => "Opsgenie Customer API key",
+    :short => '-k apiKey',
+    :long => '--key apiKey',
+    :description => 'Opsgenie Customer API key',
     :required => true
 
   option :source,
-    :short => "-s SOURCE",
-    :long => "--source SOURCE",
-    :description => "heartbeat source",
+    :short => '-s SOURCE',
+    :long => '--source SOURCE',
+    :description => 'heartbeat source',
     :required => false,
     :default => Socket.gethostbyname(Socket.gethostname).first # this should be fqdn
 
@@ -60,10 +60,10 @@ class OpsgenieHeartbeat < Sensu::Plugin::Check::CLI
 
   def opsgenie_heartbeat
     params = {}
-    params["apiKey"] = config[:api_key]
-    params["source"] = config[:source]
+    params['apiKey'] = config[:api_key]
+    params['source'] = config[:source]
 
-    uri = URI.parse("https://api.opsgenie.com/v1/json/customer/heartbeat")
+    uri = URI.parse('https://api.opsgenie.com/v1/json/customer/heartbeat')
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = true
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE


### PR DESCRIPTION
This change introduces another config option to the opsgenie heartbeat check, allowing to specify the source.  The default setting equals the nodes FQDN.

In addition to that, the customerKey key was replaced by apiKey; just to be in line [with the API docs](http://support.opsgenie.com/customer/portal/articles/1123260).
