### PR TITLE
Output a metric that lists the number of cpus on the box

### DIFF
--- a/plugins/system/load-metrics.rb
+++ b/plugins/system/load-metrics.rb
@@ -48,6 +48,13 @@ class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
     :boolean => true,
     :default => false
 
+  option :core_count,
+    :description => 'Include count of cpu/cores',
+    :short => '-c',
+    :long => '--core-count',
+    :boolean => true,
+    :default => false
+
   def number_of_cores
     @cores ||= File.readlines('/proc/cpuinfo').select { |l| l =~ /^processor\s+:/ }.count
   end
@@ -73,6 +80,10 @@ class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
            :fifteen => result[2]
          }
       }
+    end
+
+    if config[:core_count]
+      metrics[:load_avg][:total] = number_of_cores
     end
 
     metrics.each do |parent, children|


### PR DESCRIPTION
I wanted to be able to track the number of cores on the boxes for 2 reasons.  1) I've actually had linux 'drop a core' after running for a while and burning the core out under heavy load.  This helps with monitoring for that. 2) I can use the count of cores and the total load to compute load percent in graphite.
