### PR TITLE
show zero messages if there are no queues configured

### DIFF
--- a/plugins/rabbitmq/check-rabbitmq-messages.rb
+++ b/plugins/rabbitmq/check-rabbitmq-messages.rb
@@ -65,7 +65,7 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
   def run
     rabbitmq = get_rabbitmq_info
     overview = rabbitmq.overview
-    total = overview['queue_totals']['messages']
+    if overview['queue_totals'].is_a?(Hash) then total = overview['queue_totals']['messages'] else total = 0 end
     message "#{total}"
     critical if total > config[:critical].to_i
     warning if total > config[:warn].to_i


### PR DESCRIPTION
If you dont have any queues, the plugin exits non zero, instead it should supply 0. 
This not very elegant code, any suggestions?
