### PR TITLE
Determine _local url according to the elastic search server version

### DIFF
--- a/plugins/elasticsearch/check-es-cluster-status.rb
+++ b/plugins/elasticsearch/check-es-cluster-status.rb
@@ -52,25 +52,17 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
 
   def pre_one_point_oh?
     version = get_version
-    cur_version = version.split('.')
-    min_version = ["1","0","0"]
-
-    length = [cur_version.length, min_version.length].max - 1
-    cur_version.fill(0, cur_version.length..length)
-    min_version.fill(0, min_version.length..length)
-
-    (0..length).each { |i|
-       val = cur_version[i].to_i - min_version[i].to_i
-       return val < 0 if val != 0
-    }
-
-    false
+    version.start_with('0')
   end
 
   # API endpoint changed in 1.0.
   def local_uri
-    return "/_cluster/nodes/_local" if pre_one_point_oh?
-    return "/_nodes/_local"
+      uri = "/_nodes/_local"
+      if pre_one_point_oh? then
+          uri = "/_cluster/nodes/_local"
+      end
+
+      uri
   end
 
   def is_master


### PR DESCRIPTION
The elastic search health check uses a URI for 0.90.  This change will get the version from the server and determine which URI to use.  I've noticed some of the other checks just default to 1.x URIs, but I preferred not to break existing installs with this update.
