### PR TITLE
more explicit error message

### DIFF
--- a/plugins/mysql/mysql-replication-status.rb
+++ b/plugins/mysql/mysql-replication-status.rb
@@ -81,7 +81,13 @@ class CheckMysqlReplicationStatus < Sensu::Plugin::Check::CLI
             row[key] =~ /Yes/
           end
 
-          critical "slave not running" unless slave_running
+          output = "Slave not running!"
+          output += " STATES:"
+          output += " Slave_IO_Running=#{row['Slave_IO_Running']}"
+          output += ", Slave_SQL_Running=#{row['Slave_SQL_Running']}"
+          output += ", LAST ERROR: #{row['Last_SQL_Error']}"
+
+          critical output unless slave_running
 
           replication_delay = row['Seconds_Behind_Master'].to_i
 


### PR DESCRIPTION
Our DBAs love this extended error message. They know upfront what's going on. Thought I'd share it with everyone.

Example output:

CheckMysqlReplicationStatus CRITICAL: Slave not running! STATES: Slave_IO_Running=Yes, Slave_SQL_Running=No, LAST ERROR: Error executing row event: 'Table 'test.t2' doesn't exist'
