### PR TITLE
fix json syntax in plugin example configs

### DIFF
--- a/handlers/metrics/statuspageio_metrics.json
+++ b/handlers/metrics/statuspageio_metrics.json
@@ -4,7 +4,7 @@
         "page_id": "my_page_id",
         "metrics": {
             "some.metric.identifier": "my_metric_id",
-            "another.metric.identifier": "another_metric_id",
+            "another.metric.identifier": "another_metric_id"
         }
     }
 }

--- a/handlers/notification/campfire.json
+++ b/handlers/notification/campfire.json
@@ -1,7 +1,7 @@
 { "campfire":
   {
     "room": "devops",
-    "room_id" : "123456"
+    "room_id" : "123456",
     "account": "subdomain",
     "token": "xxxxxxxxxxxxxxxxxxx"
   }

--- a/handlers/notification/flowdock.json
+++ b/handlers/notification/flowdock.json
@@ -1,5 +1,5 @@
 {
   "flowdock": {
-    "auth_token": "FLOWDOCK_API_TOKEN",
+    "auth_token": "FLOWDOCK_API_TOKEN"
   }
 }

--- a/handlers/notification/splunkstorm.json
+++ b/handlers/notification/splunkstorm.json
@@ -1,6 +1,6 @@
 {
   "splunkstorm": {
-    "project_id": '12345',
-    "access_token": 'abcde'
+    "project_id": "12345",
+    "access_token": "abcde"
   }
 }


### PR DESCRIPTION
Several of the example configs contained invalid JSON.
