### PR TITLE
url-escape the 'target' parameter

### DIFF
--- a/plugins/graphite/check-data.rb
+++ b/plugins/graphite/check-data.rb
@@ -9,7 +9,6 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'open-uri'
-require 'uri'
 
 class CheckGraphiteData < Sensu::Plugin::Check::CLI
 


### PR DESCRIPTION
If the target parameter includes characters such as ',' or '"', the following error occurs: `URI::InvalidURIError: bad URI(is not URI?)`.  This change prevents this from occurring.
