### PR TITLE
Add timeout option to check-snmp (preserve current built-in default)

### DIFF
--- a/plugins/snmp/check-snmp.rb
+++ b/plugins/snmp/check-snmp.rb
@@ -65,7 +65,10 @@ class CheckSNMP < Sensu::Plugin::Check::CLI
 
   def run
     begin
-      manager = SNMP::Manager.new(:host => "#{config[:host]}", :community => "#{config[:community]}", :version => config[:snmp_version].to_sym, :timeout => config[:timeout].to_i)
+      manager = SNMP::Manager.new(:host => "#{config[:host]}",
+                                  :community => "#{config[:community]}",
+                                  :version => config[:snmp_version].to_sym,
+                                  :timeout => config[:timeout].to_i)
       response = manager.get(["#{config[:objectid]}"])
     rescue SNMP::RequestTimeout
       unknown "#{config[:host]} not responding"


### PR DESCRIPTION
Timeout needed in some cases for slow devices (the default in the ruby SNMP::Manager config is 1 second, which is preserved here as the default value).
