### PR TITLE
loadaverage needs to take into account the number of cores

### DIFF
--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -148,11 +148,13 @@ module Sensu
       end
 
       def proc_loadavg_metrics
+        @cores ||= File.readlines('/proc/cpuinfo').select { |l| l =~ /^processor\s+:/ }.count
+        
         read_file('/proc/loadavg') do |proc_loadavg|
           values = proc_loadavg.split(/\s+/).take(3).map(&:to_f)
-          add_metric('load_avg', '1_min', values[0])
-          add_metric('load_avg', '5_min', values[1])
-          add_metric('load_avg', '15_min', values[2])
+          add_metric('load_avg', '1_min', (values[0] / @cores))
+          add_metric('load_avg', '5_min', (values[1] / @cores))
+          add_metric('load_avg', '15_min', (values[2] / @cores))
           yield
         end
       end


### PR DESCRIPTION
From the uptime manpage:

System load averages is the average number of processes that are either in a runnable or uninterruptable state.  A process in a runnable state is  either  using  the CPU  or  waiting  to use the CPU. A process in uninterruptable state is waiting for some I/O access, eg waiting for disk. The averages are taken over the three time intervals.  Load averages are not normalized for the number of CPUs in a system, so a load average of 1 means a single CPU system is loaded all the time while on a 4 CPU system it means it was idle 75% of the time.
