### PR TITLE
Checks for ElasticSearch 0.9x and 1.x

### DIFF
--- a/plugins/elasticsearch/check-es-cluster-status.rb
+++ b/plugins/elasticsearch/check-es-cluster-status.rb
@@ -46,13 +46,13 @@ class ESClusterStatus < Sensu::Plugin::Check::CLI
     end
   end
 
-  def version
+  def get_es_version
     info = get_es_resource('/')
     info['version']['number']
   end
 
   def is_master
-    if Gem::Version.new(version) >= Gem::Version.new('1.0.0')
+    if Gem::Version.new(get_es_version) >= Gem::Version.new('1.0.0')
       master = get_es_resource('_cluster/state/master_node')['master_node']
       local = get_es_resource('/_nodes/_local')
     else


### PR DESCRIPTION
`/_cluster/nodes/_local` has been retired with ES 1.0, so this check does not work anymore.
By identifying the cluster version before running the check, we can adjust the URL based on the version.

This has been tested on ElasticSearch 1.0 and 0.90.11
