### PR TITLE
Remove HTTP check mode and TCP check mode from check-ping.rb. Then add ping timeout option.

### DIFF
--- a/plugins/ping/check-ping.rb
+++ b/plugins/ping/check-ping.rb
@@ -1,19 +1,17 @@
 #!/usr/bin/env ruby
-# Check-ping
-# ===
 #
-# This is a simple Ping check script for Sensu, Currently works with
-#  ICMP, HTTP and TCP.
+# This is a simple Ping check script for Sensu.
 #
 # Requires "net-ping" gem
 #
 # Examples:
 #
-#   check-ping -h host -t type -p port    => port option is for HTTP ping
+#   check-ping -h host -T timeout
 #
-#  Default host is "google.com", change to if you dont want to pass host
-# option
+#  Default host is "localhost"
+#
 #  Author Deepak Mohan Dass   <deepakmdass88@gmail.com>
+#
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
@@ -24,37 +22,20 @@ require 'net/ping'
 
 class CheckPING < Sensu::Plugin::Check::CLI
 
-  option :port,
-    :short => '-p port',
-    :default => "80"
-
   option :host,
     :short => '-h host',
-    :default => 'google.com'
+    :default => 'localhost'
 
-  option :type,
-    :short => '-t type',
-    :default => 'HTTP'
+  option :timeout,
+    :short => '-T timeout',
+    :default => '5'
 
   def run
-    pt = nil
-    ping_type = config[:type].upcase
-    case ping_type
-    when 'HTTP'
-      pt = Net::Ping::HTTP.new(config[:host], config[:port], 10)
-    when 'ICMP'
-      pt = Net::Ping::ICMP.new(config[:host], config[:port], 10)
-    when 'TCP'
-      pt = Net::Ping::TCP.new(config[:host], config[:port], 10)
+    pt = Net::Ping::External.new(config[:host], nil, config[:timeout])
+    if pt.ping?
+      ok "ICMP ping successful for host: #{config[:host]}"
     else
-      unknown "Unknown type specified: #{config[:type]}"
-    end
-    if pt != nil
-      if pt.ping?
-        ok "#{ping_type} ping successful for host: #{config[:host]}"
-      else
-        critical "#{ping_type} ping unsuccessful for host: #{config[:host]}"
-      end
+      critical "ICMP ping unsuccessful for host: #{config[:host]}"
     end
   end
 end


### PR DESCRIPTION
#### 1. remove HTTP check mode and TCP check mode

HTTP check and TCP port check already exist. these are in security/check-ports.tb and http/check-http.rb

In addition, TCP check mode does not work on internal network.
For example, port 81 is not open in my machines.

```
/opt/sensu/embedded/bin/ruby /etc/sensu/plugins/check-ping.rb -t TCP -h localhost -p 81
```

```
/opt/sensu/embedded/bin/ruby /etc/sensu/plugins/check-ping.rb -t TCP -h 192.168.1.101 -p 81
```

the result below is in both cases.

```
CheckPING OK: TCP ping successful for host: localhost(or 192.168.1.101)
```

I think the result should be NG.
#### 2. Add ping timeout option.

You can set ping timeout using -T option.

I am a beginner in Ruby. I am not knowledgeable about net-ping library.
Please check and tell me if there are any problems.
If you are ok, please merge pull request.

Hiroaki.
