### PR TITLE
embed admin gui url into mail body

### DIFF
--- a/handlers/notification/mailer.json
+++ b/handlers/notification/mailer.json
@@ -1,5 +1,6 @@
 {
   "mailer": {
+    "admin_gui": "http://admin.example.com:8080/",
     "mail_from": "sensu@example.com",
     "mail_to": "monitor@example.com",
     "smtp_address": "smtp.example.org",

--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -37,6 +37,7 @@ class Mailer < Sensu::Handler
   end
 
   def handle
+    admin_gui = settings['mailer']['admin_gui'] || 'http://localhost:8080/'
     mail_to = settings['mailer']['mail_to']
     mail_from =  settings['mailer']['mail_from']
 
@@ -53,6 +54,7 @@ class Mailer < Sensu::Handler
     playbook = "Playbook:  #{@event['check']['playbook']}" if @event['check']['playbook']
     body = <<-BODY.gsub(/^\s+/, '')
             #{@event['check']['output']}
+            Admin GUI: #{admin_gui}
             Host: #{@event['client']['name']}
             Timestamp: #{Time.at(@event['check']['issued'])}
             Address:  #{@event['client']['address']}


### PR DESCRIPTION
If you receive alert mail, you can go to your admin console(like dashboard) quickly by tapping "Admin GUI" url in mail body.

![photo1](https://cloud.githubusercontent.com/assets/621569/2773876/15269f12-caa9-11e3-8601-c389e7af81f3.png)
