### PR TITLE
Use "Threads_connected" instead of "Max_used_connections"

### DIFF
--- a/plugins/mysql/mysql-connections.rb
+++ b/plugins/mysql/mysql-connections.rb
@@ -72,7 +72,7 @@ class CheckMySQLHealth < Sensu::Plugin::Check::CLI
             fetch('Value').
             to_i
         used_con = db.
-            query("SHOW GLOBAL STATUS LIKE 'Max_used_connections'").
+            query("SHOW GLOBAL STATUS LIKE 'Threads_connected'").
             fetch_hash.
             fetch('Value').
             to_i


### PR DESCRIPTION
SHOW GLOBAL STATUS LIKE 'Max_used_connections' is not the number of current connections.
Max_used_connections does not decrease unless MySQL process stop.
It keeps the detected maximum connections since MySQL server started.
Use SHOW GLOBAL STATUS LIKE 'threads_connected' instead.

See also
https://dev.mysql.com/doc/refman/5.5/en/server-status-variables.html
https://dev.mysql.com/doc/refman/5.6/en/server-status-variables.html

> Max_used_connections
> The maximum number of connections that have been in use simultaneously since the server started.
> Threads_connected
> The number of currently open connections.

Hiroaki
