### PR TITLE
es-node-graphite 1.x fix, bugfix

### DIFF
--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -55,7 +55,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     :description => "Elasticsearch port.",
     :short => "-p PORT",
     :long => "--port PORT",
-    :proc => proc {|a| a.to_i }
+    :proc => proc {|a| a.to_i },
     :default => 9200
 
   option :request_timeout,


### PR DESCRIPTION
- Add port option (default to 9200)
- Add request timeout configuration (default to 30s)
- Add flags to disable:
  - jvm stats
  - os stats
  - process stats
- Move URI request to function
- Add version detection (ES API Changed in 1.x)
- Reorder stats query string to match the order in the ES 1.1 docs
  - (For personal reasons)
- Remove some confusing stat being output
  - Some combination of gc collection time and old gen storage?
- Enumerate indices stats
- Typo - there is no 'network.transport.current_estab' key
  - checked back to 0.20.x for this
- Add uptime, which is confusing in that it should be somewhere else, since the 'os' key seems to imply it'd be the OS stats..?
- Add thread_pool stats
