### PR TITLE
Sensu handler to run Ansible playbook

### DIFF
--- a/handlers/other/ansible.json
+++ b/handlers/other/ansible.json
@@ -1,0 +1,6 @@
+{
+  "ansible: {
+    "command": "/usr/bin/ansible-playbook",
+    "playbook": "playbook.yml"
+  }
+}

--- a/handlers/other/ansible.rb
+++ b/handlers/other/ansible.rb
@@ -1,0 +1,45 @@
+#!/usr/bin/env ruby
+#
+# Sensu Handler: ansible
+#
+# This handler runs an Ansible playbook (http://www.ansible.com/) passing the
+# check event as additional variables.
+#
+# Two settings are supported in ansible.json:
+#   command  : (optional) the ansible-playbook command
+#   playbook : (required) the playbook to run
+#
+# Additionally, the playbook may be over ridden by the check definition.
+#
+# Copyright 2014 Aaron Iles <aaron.iles@gmail.com>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-handler'
+require 'json'
+
+class Ansible < Sensu::Handler
+
+  def handle
+    ansible = settings['ansible']['command'] || 'ansible-playbook'
+    playbook = settings['ansible']['playbook'] || nil
+    extra_vars = JSON.generate(@event)
+
+    unless @event['check']['ansible'].nil?
+      playbook = @event['check']['ansible']['playbook'] || playbook
+    end
+
+    command = "#{ansible} -e '#{extra_vars}' #{playbook}"
+    output = `#{command}`
+
+    if $?.exitstatus > 0
+      puts output
+      exit 1
+    else
+      puts "SUCCESS: #{command}"
+    end
+  end
+
+end


### PR DESCRIPTION
A Sensu event handler that passes the check event as extra variables to
an Ansible playbook. Useful for running playbooks to automatically
remediate known issues.
