### PR TITLE
Sentry Handler

### DIFF
--- a/handlers/other/sentry.rb
+++ b/handlers/other/sentry.rb
@@ -89,9 +89,5 @@ request = Net::HTTP::Post.new(@uri.path)
 begin
   request.body = packet.to_json
   request.add_field('X-Sentry-Auth', auth_header)
-
-  response = @client.request(request)
-  puts response
-  puts auth_header
-  puts packet
+  @client.request(request)
 end


### PR DESCRIPTION
This handler sends events to a sentry server. see www.getsentry.com for info.

Insert your own DSN at line 36.
If using HTTPS/SSL change line 45 to `@client.use_ssl = true`
