### PR TITLE
http-check: Correct documentation for -b and add -B

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -204,7 +204,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
       body = ''
     end
 
-    if config[:require_bytes] and res.body.length != config[:require_bytes]
+    if config[:require_bytes] && res.body.length != config[:require_bytes]
       critical "Response was #{res.body.length} bytes instead of #{config[:require_bytes]}" + body
     end
 


### PR DESCRIPTION
The `-b` check (specific number of bytes) was not being enforced - it was just setting the length of how much body to print with any success/failure.

Rather than change the behavior of `-b`, I added `-B` to actually enforce an exact number of bytes and left `-b` as a way to print a bit of the response body since that's useful too.
