### PR TITLE
Add 'absent' flag to check-tail-rb

### DIFF
--- a/plugins/files/check-tail.rb
+++ b/plugins/files/check-tail.rb
@@ -67,7 +67,7 @@ class Tail < Sensu::Plugin::Check::CLI
     unknown "No log file specified" unless config[:file]
     unknown "No pattern specified" unless config[:pattern]
     if File.exists?(config[:file])
-      if not config[:absent]
+      if !config[:absent]
         if pattern_match?
           send(
             config[:warn_only] ? :warning : :critical,


### PR DESCRIPTION
Optionally allow the check-tail command to fail if the pattern is not
found. This inverts the default behaviour of failing when the pattern is
present. The default behaviour is unchanged.
