### PR TITLE
Optionally require PID file to be present

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -86,6 +86,13 @@ class CheckProcs < Sensu::Plugin::Check::CLI
     :long => '--file-pid PID',
     :description => 'Check against a specific PID'
 
+  option :require_pid,
+    :short => '-F',
+    :long => '--require-pid',
+    :description => 'Fail if PID file not found',
+    :boolean => true,
+    :default => false
+
   option :vsz,
     :short => '-z VSZ',
     :long => '--virtual-memory-size VSZ',
@@ -132,7 +139,10 @@ class CheckProcs < Sensu::Plugin::Check::CLI
     if File.exists?(path)
       File.read(path).strip.to_i
     else
-      unknown "Could not read pid file #{path}"
+      send(
+        config[:require_pid] ? :warning : :unknown,
+        "Could not read pid file #{path}"
+      )
     end
   end
 


### PR DESCRIPTION
Allow the check-procs command the fail with warning status if the PID
file can not be found. Some applications will remove the PID file after
the application exists. However, it may be desirable to fail with a
warning message to trigger appropriate notifications.
