### PR TITLE
Events can explicitly set tags

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -58,6 +58,7 @@ module Sensu
         client = event[:client]
         check = event[:check]
         tags = []
+        tags.concat(check[:tags]) unless check[:tags].nil?
         tags << client[:environment] unless client[:environment].nil?
         unless check[:subscribers].nil? || check[:subscribers].empty?
           tags.concat(client[:subscriptions] - (client[:subscriptions] - check[:subscribers]))


### PR DESCRIPTION
It would be useful to be able to have a checks set an array of tags that should be associated with a check for use by flapjack.  For instance if you want influence what flapjack does with a certain check you need to have specific tags associated with it.

Including something the following in a sensu event payload
"tags"   => ['bypass_ncsm','party_animal'],

Will then be available to flapjack when it goes to process the event.
