### PR TITLE
Added aggregate API 'limit' parameter as an option to the check-aggregate.rb plugin

### DIFF
--- a/plugins/sensu/check-aggregate.rb
+++ b/plugins/sensu/check-aggregate.rb
@@ -54,6 +54,12 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
     :default => 30,
     :proc => proc {|a| a.to_i }
 
+  option :limit,
+    :short => "-l LIMIT",
+    :long => "--limit LIMIT",
+    :description => "Limit of aggregates you want the API to return",
+    :proc => proc {|a| a.to_i }
+
   option :summarize,
     :short => "-s",
     :long => "--summarize",
@@ -108,7 +114,7 @@ class CheckAggregate < Sensu::Plugin::Check::CLI
 
   def get_aggregate
     uri = "/aggregates/#{config[:check]}"
-    issued = api_request(uri + "?age=#{config[:age]}")
+    issued = api_request(uri + "?age=#{config[:age]}" + (config[:limit] ? "&limit=#{config[:limit]}" : ""))
     unless issued.empty?
       issued_sorted = issued.sort
       time = issued_sorted.pop


### PR DESCRIPTION
Hello,

I was setting up an aggregate check and wanted a way to monitor the aggregates.  Found this plugin, but there was no option/ability to retrieve and check just the most recent aggregate.  The "--age" option only allowed me view aggregates OLDER than a certain time, and no way to view aggregates NEWER -- This seems to be by design of the 'age' option for the aggregate API, but I'm still not sure what scenario that would be used for.

Instead I wanted to add functionality for the 'limit' option in the aggregate API to accomplish my goal.

This merge request accomplishes that goal without breaking the current functionality of the plugin.

Please merge!
Thanks,
jmherbst
