### PR TITLE
Updated check-es-heap.rb to use similar checks for ElasticSearch v1.0. (...

### DIFF
--- a/plugins/elasticsearch/check-es-heap.rb
+++ b/plugins/elasticsearch/check-es-heap.rb
@@ -61,10 +61,20 @@ class ESHeap < Sensu::Plugin::Check::CLI
     end
   end
 
+  def get_es_version
+    info = get_es_resource('/')
+    info['version']['number']
+  end
+
   def get_heap_used
-    stats = get_es_resource('/_cluster/nodes/_local/stats?jvm=true')
-    node = stats['nodes'].keys.first
     begin
+      if Gem::Version.new(get_es_version) >= Gem::Version.new('1.0.0')
+        stats= get_es_resource('_nodes/_local/stats?jvm=true')
+        node = stats['nodes'].keys.first
+      else
+        stats = get_es_resource('/_cluster/nodes/_local/stats?jvm=true')
+        node = stats['nodes'].keys.first
+      end
       stats['nodes'][node]['jvm']['mem']['heap_used_in_bytes']
     rescue
       warning 'Failed to obtain heap used in bytes'


### PR DESCRIPTION
...cribbed partially from the check-es-cluster-status.rb)
