### PR TITLE
Source flapjack tags from another field from the check

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -64,6 +64,9 @@ module Sensu
         else
           tags.concat(client[:subscriptions])
         end
+        unless check[:flapjack_tags].nil? || check[:flapjack_tags].empty?
+          tags.concat(check[:flapjack_tags])
+        end
         details = ['Address:' + client[:address]]
         details << 'Tags:' + tags.join(',')
         flapjack_event = {


### PR DESCRIPTION
Enables adding arbitrary tags to the event before adding it to Flapjack's redis queue.
