### PR TITLE
Events can explicitly set tags

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -58,7 +58,7 @@ module Sensu
         client = event[:client]
         check = event[:check]
         tags = []
-        tags.concat(check[:tags]) unless check[:tags].nil?
+        tags.concat(check[:tags]) if check[:tags].is_a?(Array)
         tags << client[:environment] unless client[:environment].nil?
         unless check[:subscribers].nil? || check[:subscribers].empty?
           tags.concat(client[:subscriptions] - (client[:subscriptions] - check[:subscribers]))


### PR DESCRIPTION
After #589 was merged portertech suggested an appropriate change to guard against concat'ing a non array object.
