### PR TITLE
Add "uptime" metric

### DIFF
--- a/plugins/memcached/memcached_socket_graphite.rb
+++ b/plugins/memcached/memcached_socket_graphite.rb
@@ -62,6 +62,7 @@ class MemcachedGraphite < Sensu::Plugin::Metric::CLI::Graphite
 
   def sortMetrics(stats)
     memcachedMetrics = {}
+    memcachedMetrics['uptime'] = stats['uptime'].to_i
     memcachedMetrics['pointer_size'] = stats['pointer_size'].to_i
     memcachedMetrics['rusage_user'] = stats['rusage_user'].to_i
     memcachedMetrics['rusage_system'] = stats['rusage_system'].to_i


### PR DESCRIPTION
Tested with memcached version 1.4.15 

"uptime (32-bit unsigned integer) : Uptime (in seconds) for this memcached instance"
http://dev.mysql.com/doc/refman/5.0/en/ha-memcached-stats-general.html
