### PR TITLE
Avoid crashing on new lines in /etc/fstab

### DIFF
--- a/plugins/system/check-fstab-mounts.rb
+++ b/plugins/system/check-fstab-mounts.rb
@@ -3,7 +3,7 @@
 # Check fstab Mounts Plugin
 # ===
 #
-# Check /proc/mounts to ensure all filesystems of the requested type(s) from
+# Check /etc/mtab to ensure all filesystems of the requested type(s) from
 # fstab are currently mounted.  If no fstypes are specified, will check all
 # entries in fstab.
 #


### PR DESCRIPTION
Also handle /dev/shm mounts, which are not shown in the output of /etc/mounts. (/etc/mtab, however, records the /dev/shm mounts).

Sorry about the commit message. I meant _Avoid crashing on empty lines in /etc/fstab_
