### PR TITLE
Convert devicemapper ID's to logical volume names

### DIFF
--- a/plugins/system/disk-metrics.rb
+++ b/plugins/system/disk-metrics.rb
@@ -11,13 +11,12 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
     :short => "-s SCHEME",
     :long => "--scheme SCHEME",
     :default => "#{Socket.gethostname}.disk"
-    
+
   option :convert,
     :description => "Convert devicemapper to logical volume name",
     :short => "-c",
     :long => "--convert",
     :default => false
-
 
   def run
     # http://www.kernel.org/doc/Documentation/iostats.txt
@@ -33,7 +32,7 @@ class DiskGraphite < Sensu::Plugin::Metric::CLI::Graphite
       if config[:convert]
         if dev =~ /^dm-.*$/
           dev = `lsblk -P -o NAME /dev/"#{dev}"| cut -d\\" -f2`.chomp!
-      	end
+        end
       end
       next if stats == ['0'].cycle.take(stats.size)
 


### PR DESCRIPTION
Allow for the ability to optionally convert devicemapper id's to their logical volume names.
