### PR TITLE
Include filesystem type in inode disk check

### DIFF
--- a/plugins/system/check-disk.rb
+++ b/plugins/system/check-disk.rb
@@ -98,9 +98,9 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       end
     end
 
-    `df -Pi`.split("\n").drop(1).each do |line|
+    `df -PTi`.split("\n").drop(1).each do |line|
       begin
-        _fs, _inodes, _used, _avail, capacity, mnt = line.split
+        _fs, type, _inodes, _used, _avail, capacity, mnt = line.split
         next if config[:includeline] && !config[:includeline].find { |x| line.match(x) }
         next if config[:fstype] && !config[:fstype].include?(type)
         next if config[:ignoretype] && config[:ignoretype].include?(type)


### PR DESCRIPTION
Filesystem type should be included in the `df` output for the inode check
since there is the option to exclude based on file system type.

A bug, I think, that we found when I tried to exclude some network mount types from the check and still received inode warnings for those mounts.
