### PR TITLE
Set victorops message_type to WARNING on check status 1

### DIFF
--- a/handlers/notification/victorops.rb
+++ b/handlers/notification/victorops.rb
@@ -27,7 +27,12 @@ class VictorOps < Sensu::Handler
 
         case @event['action']
         when 'create'
-          message_type = 'CRITICAL'
+          case @event['check']['status']
+          when 1
+            message_type = 'WARNING'
+          else
+            message_type = 'CRITICAL'
+          end
         when 'resolve'
           message_type = 'RECOVERY'
         end


### PR DESCRIPTION
While dumping all events into critical works, victorops has the capability of creating incidents for warnings _or_ criticals, so the added granularity just serves for finer-grained control.
