### PR TITLE
Handle EOFError from socket closing unexpectedly.

### DIFF
--- a/plugins/network/check-banner.rb
+++ b/plugins/network/check-banner.rb
@@ -61,6 +61,8 @@ class CheckBanner < Sensu::Plugin::Check::CLI
       critical "Connection or read timed out"
     rescue Errno::EHOSTUNREACH
       critical "Check failed to run: No route to host"
+    rescue EOFError
+      critical "Connection closed unexpectedly"
     end
   end
 


### PR DESCRIPTION
Without this, an unexpected socket close results in:

CheckBanner CRITICAL: Check failed to run: end of file reached, ["/etc/sensu/plugins/network/check-banner.rb:56:in `readline'", "/etc/sensu/plugins/network/check-banner.rb:56:in`block in get_banner'", "/opt/sensu/embedded/lib/ruby/2.0.0/timeout.rb:66:in `timeout'", "/opt/sensu/embedded/lib/ruby/2.0.0/timeout.rb:97:in`timeout'", "/etc/sensu/plugins/network/check-banner.rb:53:in `get_banner'", "/etc/sensu/plugins/network/check-banner.rb:68:in`run'", "/opt/sensu/embedded/lib/ruby/gems/2.0.0/gems/sensu-plugin-0.2.1/lib/sensu-plugin/cli.rb:56:in `block in class:CLI'"]
