### PR TITLE
replaced client_subscriptions loop with check_subscribers loop

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -39,7 +39,7 @@ class Mailer < Sensu::Handler
   def build_mail_to_list
     mail_to = settings['mailer']['mail_to']
     if settings['mailer'].has_key?('subscriptions')
-      @event['client']['subscriptions'].each do |sub|
+      @event['check']['subscribers'].each do |sub|
         if settings['mailer']['subscriptions'].has_key?(sub)
           mail_to << ", #{settings['mailer']['subscriptions'][sub]['mail_to']}"
         end


### PR DESCRIPTION
Hi @zarry, made a little change to the mail_to with multiple subscriptions.
I figured out that if a client is many subscriptions, the mail_to reads the client subscriptions instead of the event subscription. This causes email to go to wrong recipients.

Lets say client node a has subscriptions `"subscriptions"=>["nginx", "haproxy",  "all"]`. 
I created a mail_to `mailer: { "subscriptions": { "nginx": { "mail_to": "sys@example.com" }, "haproxy": { "mail_to": "dev@example.com" } } }` and an `event on nginx` happens, the current script reads client subscriptions and send it to sys and dev. My fix makes sure its sent to ony sys only.

Let me know what you think about the modification.
Thanks.
