### PR TITLE
added test to check if queue and message stats are empty

### DIFF
--- a/plugins/rabbitmq/rabbitmq-overview-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-overview-metrics.rb
@@ -94,7 +94,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
     overview = rabbitmq.overview
 
     # overview['queue_totals']['messages']
-    if overview.has_key?('queue_totals') and !overview['queue_totals'].empty?
+    if overview.has_key?('queue_totals') && !overview['queue_totals'].empty?
       output "#{config[:scheme]}.queue_totals.messages.count", overview['queue_totals']['messages'], timestamp
       output "#{config[:scheme]}.queue_totals.messages.rate", overview['queue_totals']['messages_details']['rate'], timestamp
 
@@ -107,7 +107,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       output "#{config[:scheme]}.queue_totals.messages_ready.rate", overview['queue_totals']['messages_ready_details']['rate'], timestamp
     end
 
-    if overview.has_key?('message_stats') and !overview['message_stats'].empty?
+    if overview.has_key?('message_stats') && !overview['message_stats'].empty?
       # overview['message_stats']['publish']
       if overview['message_stats'].include?('publish')
         output "#{config[:scheme]}.message_stats.publish.count", overview['message_stats']['publish'], timestamp


### PR DESCRIPTION
If there are no queue yet then queue_totals and message_stats arrays are empty so you get a Ruby error.  Added a test to check to see if the array is empty and if it is skip the processing.

Ruby error is: TypeError: no implicit conversion of String into Integer
