### PR TITLE
Update extensions/handlers/redis_output.rb

### DIFF
--- a/extensions/handlers/redis_output.rb
+++ b/extensions/handlers/redis_output.rb
@@ -11,11 +11,13 @@ module Sensu::Extension
     end
 
     def post_init
-      @redis = Sensu::Redis.connect({
-        :host => @settings["redis_output"]["host"],
-        :port => @settings["redis_output"]["port"] || 6379,
-        :database => @settings["redis_output"]["db"] || 0,
-      })
+      if @settings["redis_output"].is_a?(Hash)
+        @redis = Sensu::Redis.connect({
+          :host => @settings["redis_output"]["host"] || 127.0.0.1,
+          :port => @settings["redis_output"]["port"] || 6379,
+          :database => @settings["redis_output"]["db"] || 0,
+        })
+      end
     end
 
     def run(event)


### PR DESCRIPTION
o Unless redis_output is defined, redis_output will cause sensu to bail (see https://gist.github.com/xyntrix/2e2323c0db6128ba7389).  This will check to see if redis_output settings are defined. If not, move along.
