### PR TITLE
snmp-metrics bugfix

### DIFF
--- a/plugins/snmp/snmp-metrics.rb
+++ b/plugins/snmp/snmp-metrics.rb
@@ -59,9 +59,6 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
     :boolean => true
 
   def run
-    if config[:graphite]
-      config[:host] = config[:host].gsub('.', '_')
-    end
     begin
       manager = SNMP::Manager.new(:host => "#{config[:host]}", :community => "#{config[:community]}", :version => config[:snmp_version].to_sym)
       response = manager.get(["#{config[:objectid]}"])
@@ -69,6 +66,9 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
       unknown "#{config[:host]} not responding"
     rescue Exception => e
       unknown "An unknown error occured: #{e.inspect}"
+    end
+    if config[:graphite]
+      config[:host] = config[:host].gsub('.', '_')
     end
     response.each_varbind do |vb|
       if config[:prefix]


### PR DESCRIPTION
Issue #528 - config[:host] should not be modified until after it has been used to establish the SNMP connection socket.
