### PR TITLE
Remove extraneous $PERCENT modification and do not divide by zero (!!!)

### DIFF
--- a/plugins/system/check-swap-percentage.sh
+++ b/plugins/system/check-swap-percentage.sh
@@ -33,10 +33,10 @@ else
 
   OUTPUT="Swap usage: $PERCENT%, $USED/$TOTAL"
 
-  if [[ $PERCENT -ge $CRIT ]] ; then
+  if [ ! $(echo "$PERCENT >= $CRIT" | bc) ] ; then
     echo "SWAP CRITICAL - $OUTPUT"
     exit 2
-  elif [[ $PERCENT -ge $WARN ]] ; then
+  elif [ ! $(echo "$PERCENT >= $WARN" | bc) ] ; then
     echo "SWAP WARNING - $OUTPUT"
     exit 1
   else


### PR DESCRIPTION
This line returns an empty string on my machine. I am not sure what the original author's intent was, but it seems unnecessary to have it there.
