### PR TITLE
Fix check-netstat-tcp.rb options default

### DIFF
--- a/plugins/network/check-netstat-tcp.rb
+++ b/plugins/network/check-netstat-tcp.rb
@@ -52,7 +52,7 @@ class CheckNetstatTCP < Sensu::Plugin::Check::CLI
     :description => "Comma delimited list of states to check",
     :short => "-s STATES",
     :long => "--states STATES",
-    :default => "ESTABLISHED",
+    :default => ["ESTABLISHED"],
     :proc => proc {|a| a.split(',') }
 
   option :critical,


### PR DESCRIPTION
The default for the `-s` option must be set as an array, otherwise the script crashes unless the `-s` option is explicitly specified.
