### PR TITLE
rewrite check-bluepill-procs to make monitored applications configurable

### DIFF
--- a/plugins/system/check-bluepill-procs.rb
+++ b/plugins/system/check-bluepill-procs.rb
@@ -3,18 +3,28 @@
 # Check application processes running under bluepill control
 # ===
 #
-# Specify applications to monitor with -a [APP1,APP2]
-# If this option is not provided, this check will monitor the processes
-# of all the applications that bluepill has loaded.
+# DESCRIPTION:
+#   This plugin monitors the status of applications and processes
+#   running under the bluepill process supervisor.
 #
-# Returns CRITICAL if any process is down or if a manually specified
-# application has no processes loaded
-# Returns WARNING if any process is starting or unmonitored
-# Returns OK if all processes for all specified applications are 'up'
-# or bluepill is not in $PATH
+#   Specify applications to monitor with -a [APP1,APP2]
+#   If this option is not provided, this check will monitor the processes
+#   of all the applications that bluepill has loaded.
 #
-# James Legg mail@jameslegg.co.uk
-# Matt Greensmith mgreensmith@cozy.co
+# OUTPUT:
+#   Plain-text.
+#   Returns CRITICAL if any process is down or if a manually specified
+#   application has no processes loaded
+#   Returns WARNING if any process is starting or unmonitored
+#   Returns OK if all processes for all specified applications are 'up'
+#   or bluepill is not in $PATH
+#
+# DEPENDENCIES:
+#   sensu-plugin Ruby gem
+#
+# AUTHORS:
+#   James Legg mail@jameslegg.co.uk
+#   Matt Greensmith mgreensmith@cozy.co
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.


### PR DESCRIPTION
This rewrite adds an option for specifying the bluepill-managed applications that should be monitored. If no applications are specified in the check options, it parses a list of currently-loaded applications out of bluepill and monitors all of them (same as legacy behavior).

We also significantly improve the check's parsing of bluepill's output - bluepill's behavior and exit codes differ based on whether it has one or multiple managed applications loaded.

This rewrite is backwards-compatible with the previous version.
