### PR TITLE
Allow specifying an alternate socket path

### DIFF
--- a/plugins/mysql/mysql-replication-status.rb
+++ b/plugins/mysql/mysql-replication-status.rb
@@ -41,6 +41,11 @@ class CheckMysqlReplicationStatus < Sensu::Plugin::Check::CLI
     :description => 'Database port',
     :default => 3306,
     :proc => lambda { |s| s.to_i }
+    
+  option :socket,
+    :short => '-s',
+    :long => '--socket=VALUE',
+    :description => 'Socket to use'
 
   option :user,
     :short => '-u',
@@ -92,13 +97,14 @@ class CheckMysqlReplicationStatus < Sensu::Plugin::Check::CLI
     end
     db_host = config[:host]
     db_port = config[:port]
+    db_sock = config[:socket]
 
     if [db_host, db_user, db_pass].any? {|v| v.nil? }
       unknown "Must specify host, user, password"
     end
 
     begin
-      db = Mysql.new(db_host, db_user, db_pass, nil, db_port)
+      db = Mysql.new(db_host, db_user, db_pass, nil, db_port, db_sock)
       results = db.query 'show slave status'
 
       unless results.nil?


### PR DESCRIPTION
This allows you to use this check if you have multiple mysqld's on the same server.
