### PR TITLE
Fix type-o in elasticsearch node metric plugin (es-node-graphite.rb)

### DIFF
--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -211,7 +211,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     node['thread_pool'].each do |pool, stat|
       stat.each do |k, v|
-        metrics["tread_pool.#{pool}.#{k}"] = v
+        metrics["thread_pool.#{pool}.#{k}"] = v
       end
     end
 


### PR DESCRIPTION
Fixes plugin output "tread_pool" to be "thread_pool". 
