### PR TITLE
Updated flapjack.rb for 0.13

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -56,7 +56,7 @@ module Sensu
       end
 
       def run(event_data)
-        event = Oj.load(event_data)
+        event = MultiJson.load(event_data)
         client = event[:client]
         check = event[:check]
         tags = []
@@ -79,7 +79,7 @@ module Sensu
           :time    => check[:executed],
           :tags    => tags
         }
-        @redis.lpush(options[:channel], Oj.dump(flapjack_event))
+        @redis.lpush(options[:channel], MultiJson.dump(flapjack_event))
         yield 'sent an event to the flapjack redis queue', 0
       end
     end


### PR DESCRIPTION
Currently, the flapjack handler isn't working with the new 0.13 release.

This change updates references from `Oj` to `MultiJson`.

Tested with Sensu 0.13 (omnibus) and Flapjack 0.9.3 (omnibus).
