### PR TITLE
Ensure correct jstat values are mapped to titles.

### DIFF
--- a/plugins/java/jstat-metrics.py
+++ b/plugins/java/jstat-metrics.py
@@ -197,14 +197,7 @@ class JstatMetricsToGraphiteFormat(object):
       if jstat_option == "-class":
        titles[2] = "Bytes_column2"
        titles[4] = "Bytes_column4"
-      metrics_long =[]
-      for title in titles:
-        for short_title in metric_maps:
-          if title == short_title:
-            metrics_long.append(metric_maps[short_title])
-
-      stats = dict(zip(metrics_long, values))
-      return stats
+      return dict([(metric_maps[title], values[position]) for position, title in enumerate(titles) if title in metric_maps])
 
     # Get lvmid (JVM id)
     try :


### PR DESCRIPTION
Fixes parsing of jstat output so that only short code/value pairs are mapped to
the long form and output as stats. This prevents the reporting of incorrect
values for the long form metrics titles.
