### PR TITLE
use nlwp in ps to list threadcount for debian compat

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -181,7 +181,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
         line_to_hash(line, :pid, :ppid, :pgid, :winpid, :tty, :uid, :etime, :command, :time).merge(:state => state)
       end
     else
-      read_lines('ps axwwo user,pid,vsz,rss,pcpu,thcount,state,etime,time,command').drop(1).map do |line|
+      read_lines('ps axwwo user,pid,vsz,rss,pcpu,nlwp,state,etime,time,command').drop(1).map do |line|
         line_to_hash(line, :user, :pid, :vsz, :rss, :pcpu, :thcount, :state, :etime, :time, :command)
       end
     end


### PR DESCRIPTION
on a debian / ubuntu system, the ps command will error out since thcount is an invalid parameter. 
this simply ensures that we use nlwp which works for both.
