### PR TITLE
Proxy support for machines sitting behind a proxy

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -13,7 +13,8 @@ class HipChatNotif < Sensu::Handler
 
   def handle
     apiversion = settings["hipchat"]["apiversion"] || 'v1'
-    hipchatmsg = HipChat::Client.new(settings["hipchat"]["apikey"], :api_version => apiversion)
+    proxy_url = settings["hipchat"]["proxy_url"]
+    hipchatmsg = HipChat::Client.new(settings["hipchat"]["apikey"], :api_version => apiversion, :http_proxy => proxy_url)
     room = settings["hipchat"]["room"]
     from = settings["hipchat"]["from"] || 'Sensu'
 


### PR DESCRIPTION
Just added support for going through a proxy while initializing the hipchat client.
