### PR TITLE
Add a Rubocop rake task

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,5 +2,5 @@ language: ruby
 rvm:
   - 2.1
 script:
-  - 'bundle exec rubocop --config .rubocop.yml'
+  - 'bundle exec rake rubocop'
   - 'bundle exec rake spec'

--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,10 @@
 require 'rspec/core/rake_task'
+require 'rubocop/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |r|
   r.pattern = FileList['**/**/*_spec.rb']
 end
 
-task :default => [:spec]
+Rubocop::RakeTask.new
+
+task :default => [:spec, :rubocop]


### PR DESCRIPTION
Created a rake task for Rubocop. Enables Rubocop to be ran through rake.  Makes it easier to discover Rubocop's use in the codebase
