### PR TITLE
add ability to use multiple pagerduty apikeys

### DIFF
--- a/handlers/notification/pagerduty.json
+++ b/handlers/notification/pagerduty.json
@@ -1,5 +1,11 @@
 {
   "pagerduty": {
-    "api_key": "12345"
+    "api_key": "12345",
+    "team_name1": {
+      "api_key": "23456"
+    },
+    "team_name2": {
+      "api_key": "34567"
+    }
   }
 }

--- a/handlers/notification/pagerduty.rb
+++ b/handlers/notification/pagerduty.rb
@@ -21,19 +21,24 @@ class Pagerduty < Sensu::Handler
   def handle
     description = @event['check']['notification']
     description ||= [@event['client']['name'], @event['check']['name'], @event['check']['output']].join(' : ')
+    if @event['check']['pager_team']
+      api_key = settings['pagerduty'][@event['check']['pager_team']]['api_key']
+    else
+      api_key = settings['pagerduty']['api_key']
+    end
     begin
       timeout(10) do
         response = case @event['action']
         when 'create'
           Redphone::Pagerduty.trigger_incident(
-            :service_key => settings['pagerduty']['api_key'],
+            :service_key => api_key,
             :incident_key => incident_key,
             :description => description,
             :details => @event
           )
         when 'resolve'
           Redphone::Pagerduty.resolve_incident(
-            :service_key => settings['pagerduty']['api_key'],
+            :service_key => api_key,
             :incident_key => incident_key
           )
         end


### PR DESCRIPTION
The namespacing for the json is a little weird. I'd prefer settings['pagerduty']['default']['api_key'], but I wanted to keep it backwards compatible.
