### PR TITLE
Fix and extend check-redis-slave-status

### DIFF
--- a/plugins/redis/check-redis-slave-status.rb
+++ b/plugins/redis/check-redis-slave-status.rb
@@ -32,7 +32,7 @@ class RedisSlaveCheck < Sensu::Plugin::Check::CLI
     :short => "-m",
     :long => "--master-ok",
     :description => "Do not report problem if connected instance is master",
-    :boolean => 'true',
+    :boolean => true,
     :default => false
 
   def run


### PR DESCRIPTION
I've fixed redis-check-slave-status to work correctly with redis master instances.
