### PR TITLE
eye-http plugin

### DIFF
--- a/plugins/eye/check-eye-http-status.rb
+++ b/plugins/eye/check-eye-http-status.rb
@@ -50,10 +50,10 @@ class CheckEyeHttp < Sensu::Plugin::Check::CLI
     status_doc.each do |app|
       app['subtree'].each do |group|
         group['subtree'].each do |process|
-           proc_summary = string_formatter app['name'],
-                                           group['name'],
-                                           process['name'],
-                                           process['state']
+          proc_summary = string_formatter app['name'],
+                                          group['name'],
+                                          process['name'],
+                                          process['state']
 
           puts debug(proc_summary) if config[:debug]
 
@@ -73,7 +73,7 @@ class CheckEyeHttp < Sensu::Plugin::Check::CLI
     process_statuses out
   end
 
-private
+  private
 
   def debug(s)
     "DEBUG: #{s}"


### PR DESCRIPTION
This PR adds a plugin to watch the state of processes managed with [Eye](https://github.com/kostya/eye)  via the optional HTTP API provided by the [eye-http](https://github.com/kostya/eye-http) gem.
