### PR TITLE
fix dynamodb plugins

### DIFF
--- a/plugins/aws/check-dynamodb-capacity.rb
+++ b/plugins/aws/check-dynamodb-capacity.rb
@@ -19,6 +19,7 @@
 
 require "sensu-plugin/check/cli"
 require "aws-sdk"
+require "time"
 
 class CheckDynamoDB < Sensu::Plugin::Check::CLI
   option :access_key_id,

--- a/plugins/aws/check-dynamodb-throttle.rb
+++ b/plugins/aws/check-dynamodb-throttle.rb
@@ -14,6 +14,7 @@
 
 require "sensu-plugin/check/cli"
 require "aws-sdk"
+require "time"
 
 class CheckDynamoDB < Sensu::Plugin::Check::CLI
   option :access_key_id,


### PR DESCRIPTION
add `require "time"` for `Time.parse`
