### PR TITLE
check-ping.rb: Try ping multiple times

### DIFF
--- a/plugins/ping/check-ping.rb
+++ b/plugins/ping/check-ping.rb
@@ -63,7 +63,7 @@ class CheckPING < Sensu::Plugin::Check::CLI
   def run
     result = []
     pt = Net::Ping::External.new(config[:host], nil, config[:timeout])
-    (0 .. config[:count] - 1).each do |i|
+    config[:count].times do |i|
       sleep(config[:interval]) unless i == 0
       result[i] = pt.ping?
     end


### PR DESCRIPTION
This patch modifies `check-ping.rb` so that it can try ping multiple times and check the successful ratio rather than single ping result.
