### PR TITLE
Fixes doc on one parameter

### DIFF
--- a/plugins/system/load-metrics.rb
+++ b/plugins/system/load-metrics.rb
@@ -9,7 +9,7 @@
 # Load per processor
 # ------------------
 #
-# Optionally, with `--load-per-proc`, this plugin will calculate load per
+# Optionally, with `--per-core`, this plugin will calculate load per
 # processor from the raw load average by dividing load average by the number
 # of processors.
 #


### PR DESCRIPTION
The command line option to calculate load per processor is `--per-core`.
