### PR TITLE
use notification key for summary if available, otherwise use output

### DIFF
--- a/extensions/handlers/flapjack.rb
+++ b/extensions/handlers/flapjack.rb
@@ -69,12 +69,13 @@ module Sensu
         end
         details = ['Address:' + client[:address]]
         details << 'Tags:' + tags.join(',')
+        details << "Raw Output: #{check[:output]}" if check[:notification]
         flapjack_event = {
           :entity  => client[:name],
           :check   => check[:name],
           :type    => 'service',
           :state   => Sensu::SEVERITIES[check[:status]] || 'unknown',
-          :summary => check[:output],
+          :summary => check[:notification] || check[:output] ,
           :details => details.join(' '),
           :time    => check[:executed],
           :tags    => tags


### PR DESCRIPTION
This enables the check[:notification] key to be optionally used for additional check info / context, falls back to existing behavior if the notification key is absent
