### PR TITLE
allow mailer-ses to use other regions, still defaults to us-east-1

### DIFF
--- a/handlers/notification/mailer-ses.json
+++ b/handlers/notification/mailer-ses.json
@@ -3,6 +3,7 @@
     "mail_from": "sensu@example.com",
     "mail_to": "monitor@example.com",
     "aws_access_key": "myawsaccesskey",
-    "aws_secret_key": "myawssecretkey"
+    "aws_secret_key": "myawssecretkey",
+    "aws_ses_endpoint": "email.us-east-1.amazonaws.com"
   }
 }

--- a/handlers/notification/mailer-ses.rb
+++ b/handlers/notification/mailer-ses.rb
@@ -30,7 +30,8 @@ class Mailer < Sensu::Handler
       :mail_to   => settings['mailer-ses']['mail_to'],
       :mail_from => settings['mailer-ses']['mail_from'],
       :aws_access_key => settings['mailer-ses']['aws_access_key'],
-      :aws_secret_key => settings['mailer-ses']['aws_secret_key']
+      :aws_secret_key => settings['mailer-ses']['aws_secret_key'],
+      :aws_ses_endpoint => settings['mailer-ses']['aws_ses_endpoint']
     }
 
     body = <<-BODY.gsub(/^ {14}/, '')
@@ -47,7 +48,8 @@ class Mailer < Sensu::Handler
 
     ses = AWS::SES::Base.new(
       :access_key_id     => params[:aws_access_key],
-      :secret_access_key => params[:aws_secret_key]
+      :secret_access_key => params[:aws_secret_key],
+      :server            => params[:aws_ses_endpoint]
     )
 
     begin


### PR DESCRIPTION
SES is available in multiple regions: http://docs.aws.amazon.com/ses/latest/DeveloperGuide/regions.html

aws-ses gem supports "server": https://github.com/drewblas/aws-ses#connecting-to-a-server-from-another-region

This patch allows us to use mailer-ses with other regions.
