### PR TITLE
Adds tp_stat conditional around thread_pool metrics collection.

### DIFF
--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -208,9 +208,11 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     metrics['network.tcp.curr_estab']           = node['network']['tcp']['curr_estab']
     metrics['network.tcp.estab_resets']         = node['network']['tcp']['estab_resets']
 
-    node['thread_pool'].each do |pool, stat|
-      stat.each do |k, v|
-        metrics["thread_pool.#{pool}.#{k}"] = v
+    if tp_stats
+      node['thread_pool'].each do |pool, stat|
+        stat.each do |k, v|
+          metrics["thread_pool.#{pool}.#{k}"] = v
+        end
       end
     end
 


### PR DESCRIPTION
The option to not track `thread_pool` metrics exists however it is not applied in the code (see https://github.com/cotap/sensu-community-plugins/blob/7720498ef1dc952a0a8680c180453dab18660bf2/plugins/elasticsearch/es-node-graphite.rb#L85) . Adding this if/else block around the `thread_pool` metrics collection allows a user to not track `thread_pool` metrics.
