### PR TITLE
fixed Unknown nodes from being incorrectly reported as OutOfService

### DIFF
--- a/plugins/aws/check-elb-nodes.rb
+++ b/plugins/aws/check-elb-nodes.rb
@@ -107,6 +107,7 @@ class CheckELBNodes < Sensu::Plugin::Check::CLI
     if state['OutOfService'].count > 0
       message << " (#{state['OutOfService'].join(', ')})"
     end
+    message << "; Unknown: #{state['Unknown'].count}"
     if state['Unknown'].count > 0
       message << " (#{state['Unknown'].join(', ')})"
     end


### PR DESCRIPTION
Hi,

We noticed that nodes with a `Unknown` status were incorrectly being reported as `OutOfService`:

``` bash
CheckELBNodes WARNING: InService: 2 (i-a660d3e5, i-2aef7868); OutOfService: 0 (i-a775c5e7)
```

This change fixes that and should output the following instead:

``` bash
CheckELBNodes WARNING: InService: 2 (i-a660d3e5, i-2aef7868); OutOfService: 0; Unknown: 1 (i-a775c5e7)
```

This will help us in differentiating between `Unknown` and `OutOfService` nodes and allow us to investigate further.
