### PR TITLE
Setting resp.body.size to 0 if there is no response body

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -212,11 +212,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
       warning "Certificate will expire #{warn_cert_expire}"
     end
 
-    if res.body.nil?
-      size = "0"
-    else
-      size = res.body.size
-    end
+    size = res.body.nil? ? '0' : 'res.body.size'
 
     case res.code
       when /^2/


### PR DESCRIPTION
If the response does not contain a body, it was throwing an undefined method error. This pull request checks to see if the response body is nil, and if so sets size to 0.
