### PR TITLE
Add check-influxdb.rb

### DIFF
--- a/plugins/influxdb/check-influxdb.rb
+++ b/plugins/influxdb/check-influxdb.rb
@@ -1,0 +1,66 @@
+#!/usr/bin/env ruby
+#
+# Check if /ping endopoint is responding
+# ===
+#
+# Copyright (C) 2014, Mitsutoshi Aoe <maoe@foldr.in>
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'net/http'
+require 'uri'
+require 'json'
+
+class CheckInfluxDB < Sensu::Plugin::Check::CLI
+
+  option :host,
+    :description => 'Host address of the InfluxDB server',
+    :short => '-h HOST',
+    :long => '--host HOST',
+    :default => 'localhost'
+
+  option :port,
+    :description => 'Port number of the InfluxDB server',
+    :short => '-p PORT',
+    :long => '--port PORT',
+    :proc => Proc.new {|s| s.to_i },
+    :default => 8086
+
+  option :ssl,
+    :description => 'Turn on/off SSL (default: false)',
+    :short => '-s',
+    :long => '--ssl',
+    :boolean => true,
+    :default => false
+
+  option :timeout,
+    :description =>
+      'Seconds to wait for the connection to open or read (default: 1.0s)',
+    :short => '-t SECONDS',
+    :long => '--timeout SECONDS',
+    :proc => Proc.new {|s| s.to_f },
+    :default => 1.0
+
+  def run
+    begin
+      http = Net::HTTP.new(config[:host], config[:port])
+      http.open_timeout = config[:timeout]
+      http.read_timeout = config[:timeout]
+      http.use_ssl = config[:ssl]
+      http.start do
+        status = JSON.parse(http.get('/ping').body)
+        if status == {"status" => "ok"}
+          ok status.to_s
+        else
+          critical status.to_s
+        end
+      end
+    rescue => e
+      critical e.to_s
+    end
+  end
+
+end


### PR DESCRIPTION
This plugin checks if an InfluxDB instance is working fine.

```
% ruby ./plugins/influxdb/check-influxdb.rb --help
Usage: ./plugins/influxdb/check-influxdb.rb (options)
    -h, --host HOST                  Host address of the InfluxDB server
    -p, --port PORT                  Port number of the InfluxDB server
    -s, --ssl                        Turn on/off SSL (default: false)
    -t, --timeout SECONDS            Seconds to wait for the connection to open or read (default: 1.0s)
% ruby ./plugins/influxdb/check-influxdb.rb
CheckInfluxDB OK: {"status"=>"ok"}
% ruby ./plugins/influxdb/check-influxdb.rb -h example.com
CheckInfluxDB CRITICAL: execution expired
```
