### PR TITLE
Rewrite check-ceph to no longer use sensu/io, which is absent in 0.13

### DIFF
--- a/plugins/ceph/check-ceph.rb
+++ b/plugins/ceph/check-ceph.rb
@@ -88,10 +88,12 @@ class CheckCephHealth < Sensu::Plugin::Check::CLI
       end
     rescue Timeout::Error
       begin
-        Process.kill(9,pipe.pid)
+        Process.kill(9, pipe.pid)
         Process.wait(pipe.pid)
       rescue Errno::ESRCH, Errno::EPERM
-        # Mask errors from trying to kill the timed-out process
+        # Catch errors from trying to kill the timed-out process
+        # We must do something here to stop travis complaining
+        critical "Execution timed out"
       ensure
         critical "Execution timed out"
       end


### PR DESCRIPTION
An attempt to refactor check-ceph.rb to do the same thing that sensu/io previously offered.

I've tried to copy some of the functionality and actual code from sensu/io.rb to ensure it handles things the same way - but it lacks a couple of things that sensu::io offered (process group handling, cross-platform support) as I didn't think these are likely to actually being used in this check.

Happy to make any modifications/changes if needed.
