### PR TITLE
only check local file systems

### DIFF
--- a/plugins/system/check-disk.rb
+++ b/plugins/system/check-disk.rb
@@ -78,7 +78,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
   end
 
   def read_df
-    `df -PT`.split("\n").drop(1).each do |line|
+    `df -lPT`.split("\n").drop(1).each do |line|
       begin
         _fs, type, _blocks, _used, _avail, capacity, mnt = line.split
         next if config[:includeline] && !config[:includeline].find { |x| line.match(x) }
@@ -98,7 +98,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
       end
     end
 
-    `df -PTi`.split("\n").drop(1).each do |line|
+    `df -lPTi`.split("\n").drop(1).each do |line|
       begin
         _fs, type, _inodes, _used, _avail, capacity, mnt = line.split
         next if config[:includeline] && !config[:includeline].find { |x| line.match(x) }


### PR DESCRIPTION
df can hang on remote file systems, particularly NFS file systems if the server goes away. We are (should?) only be interested in local filesystems, so add -l flag to df to only interrogate local filesystems.
