### PR TITLE
Add memory.swapUsedPercentage metric

### DIFF
--- a/spec/fixtures/meminfo_output.txt
+++ b/spec/fixtures/meminfo_output.txt
@@ -1,0 +1,42 @@
+MemTotal:        1922732 kB
+MemFree:          573744 kB
+Buffers:          123772 kB
+Cached:           298216 kB
+SwapCached:        21380 kB
+Active:           373904 kB
+Inactive:         421516 kB
+Active(anon):     125536 kB
+Inactive(anon):   247908 kB
+Active(file):     248368 kB
+Inactive(file):   173608 kB
+Unevictable:           0 kB
+Mlocked:               0 kB
+SwapTotal:       2047992 kB
+SwapFree:        1907192 kB
+Dirty:               284 kB
+Writeback:             0 kB
+AnonPages:        371536 kB
+Mapped:            15156 kB
+Shmem:                 8 kB
+Slab:             506592 kB
+SReclaimable:     475076 kB
+SUnreclaim:        31516 kB
+KernelStack:        2584 kB
+PageTables:         8016 kB
+NFS_Unstable:          0 kB
+Bounce:                0 kB
+WritebackTmp:          0 kB
+CommitLimit:     3009356 kB
+Committed_AS:     855432 kB
+VmallocTotal:   34359738367 kB
+VmallocUsed:       11584 kB
+VmallocChunk:   34359721416 kB
+HardwareCorrupted:     0 kB
+AnonHugePages:    206848 kB
+HugePages_Total:       0
+HugePages_Free:        0
+HugePages_Rsvd:        0
+HugePages_Surp:        0
+Hugepagesize:       2048 kB
+DirectMap4k:        8184 kB
+DirectMap2M:     2088960 kB

--- a/spec/plugin_stub.rb
+++ b/spec/plugin_stub.rb
@@ -1,0 +1,18 @@
+shared_context :plugin_stub do
+  # XXX: Sensu plugins run in the context of an at_exit handler. This prevents
+  # XXX: code-under-test from being run at the end of the rspec suite.
+  before(:all) do
+    Sensu::Plugin::CLI.class_eval do
+      class PluginStub
+        def run; end
+        def ok(*); end
+        def warning(*); end
+        def critical(*); end
+        def unknown(*); end
+      end
+      # rubocop:disable all
+      @@autorun = PluginStub
+      # rubocop:enable all
+    end
+  end
+end

--- a/spec/plugins/system/memory-metrics_spec.rb
+++ b/spec/plugins/system/memory-metrics_spec.rb
@@ -1,0 +1,36 @@
+require File.expand_path('../../../../plugins/system/memory-metrics', __FILE__)
+
+require 'plugin_stub'
+
+describe MemoryGraphite do
+  include_context :plugin_stub
+  let(:checker) { described_class.new }
+
+  before(:each) do
+    def checker.meminfo_output
+      File.open('spec/fixtures/meminfo_output.txt', 'r')
+    end
+  end
+
+  it 'is able to parse metrics output' do
+    metrics = checker.metrics_hash
+
+    expect(metrics['total']).to eq(1922732*1024)
+    expect(metrics['free']).to eq(573744*1024)
+    expect(metrics['buffers']).to eq(123772*1024)
+    expect(metrics['cached']).to eq(298216*1024)
+    expect(metrics['swapTotal']).to eq(2047992*1024)
+    expect(metrics['swapFree']).to eq(1907192*1024)
+    expect(metrics['dirty']).to eq(284*1024)
+  end
+
+  it 'calculates dependent metrics correctly' do
+    metrics = checker.metrics_hash
+
+    expect(metrics['swapUsed']).to eq(140800*1024)
+    expect(metrics['used']).to eq(1348988*1024)
+    expect(metrics['usedWOBuffersCaches']).to eq(927000*1024)
+    expect(metrics['freeWOBuffersCaches']).to eq(995732*1024)
+    expect(metrics['swapUsedPercentage']).to eq(6)
+  end
+end


### PR DESCRIPTION
This adds derivative swap percentage metric. Use case for this is alerting based on metrics.
I had to refactor the code a bit to make it testable, tests included.
