### PR TITLE
Stop sending two redis keys that can't be stored

### DIFF
--- a/plugins/redis/redis-graphite.rb
+++ b/plugins/redis/redis-graphite.rb
@@ -21,7 +21,8 @@ class Redis2Graphite < Sensu::Plugin::Metric::CLI::Graphite
                      'redis_git_dirty', 'redis_git_sha1', 'redis_version', '^role',
                      'run_id', '^slave', 'used_memory_human', 'used_memory_peak_human',
                      'redis_mode', 'os', 'arch_bits', 'tcp_port',
-                     'rdb_last_bgsave_status', 'aof_last_bgrewrite_status']
+                     'rdb_last_bgsave_status', 'aof_last_bgrewrite_status', 'config_file',
+                     'redis_build_id']
 
   option :host,
     :short => "-h HOST",


### PR DESCRIPTION
30/09/2014 16:43:46 :: invalid line stats.staging_redis_pubsub_i-b20aa859.redis.redis_build_id  a44a05d76f06a5d9    1412095426 received from client 10.3.1.154:35036, ignoring
30/09/2014 16:43:46 :: invalid line stats.staging_redis_pubsub_i-b20aa859.redis.config_file /etc/redis/redis.conf   1412095426 received from client 10.3.1.154:35036, ignoring
