### PR TITLE
ohai_time is an attribute, not a method

### DIFF
--- a/plugins/chef/check-chef-nodes.rb
+++ b/plugins/chef/check-chef-nodes.rb
@@ -50,7 +50,7 @@ class ChefNodesStatusChecker < Sensu::Plugin::Check::CLI
     nodes = connection.get_rest('/nodes')
     nodes.keys.map do |node_name|
       node = connection.get_rest("/nodes/#{node_name}")
-      { node_name => (Time.now - Time.at(node.ohai_time)) > config[:critical_timespan].to_i }
+      { node_name => (Time.now - Time.at(node["ohai_time"])) > config[:critical_timespan].to_i }
     end
   end
 


### PR DESCRIPTION
ohai_time is an undefined method in later versions of the chef gem

reference: https://github.com/opscode/chef/blob/8d9195e73573199317f8ec7534e4da2c93af430b/lib/chef/knife/status.rb#L60
