### PR TITLE
Allow postgres locks metric to count any type of lock

### DIFF
--- a/plugins/postgres/postgres-locks-metric.rb
+++ b/plugins/postgres/postgres-locks-metric.rb
@@ -57,7 +57,7 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   def run
     timestamp = Time.now.to_i
 
-    metrics = Hash.new(0)
+    locks_per_type = Hash.new(0)
 
     con     = PG::Connection.new(config[:hostname], config[:port], nil, nil, 'postgres', config[:user], config[:password])
     request = [
@@ -68,12 +68,13 @@ class PostgresStatsDBMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     con.exec(request.join(' ')) do |result|
       result.each do |row|
-        metrics[row['mode'].downcase.to_sym] += 1
+        lock_name = row['mode'].downcase.to_sym
+        locks_per_type[lock_name] += 1
       end
     end
 
-    metrics.each do |metric, value|
-      output "#{config[:scheme]}.locks.#{config[:db]}.#{metric}", value, timestamp
+    locks_per_type.each do |lock_type, count|
+      output "#{config[:scheme]}.locks.#{config[:db]}.#{lock_type}", count, timestamp
     end
 
     ok


### PR DESCRIPTION
Replaces an incomplete whitelist of possible lock types with an empty hash having default value of zero. This avoids an error when the [postgres lock type](http://www.postgresql.org/docs/9.2/static/explicit-locking.html#LOCKING-TABLES) is not in the whitelist.

This change should future-proof the metric against changes to existing postgres lock types or addition of new lock types.

One example that would raise exception prior to this change is when the mode column in the pg_locks database table contains "AccessShareLock".
