### PR TITLE
Added check-stats.rb graphite plugin.

### DIFF
--- a/plugins/graphite/check-stats.rb
+++ b/plugins/graphite/check-stats.rb
@@ -20,30 +20,35 @@ require 'net/http'
 require 'sensu-plugin/check/cli'
 
 class CheckGraphiteStat < Sensu::Plugin::Check::CLI
+
   option :host,
     :short => "-h HOST",
     :long => "--host HOST",
     :description => "graphite hostname",
     :proc => proc {|p| p.to_s },
     :default => "graphite"
+
   option :period,
     :short => "-p PERIOD",
     :long => "--period PERIOD",
     :description => "The period back in time to extract from Graphite. Use -24hours, -2days, -15mins, etc, same format as in Graphite",
     :proc => proc {|p| p.to_s },
     :required => true
+
   option :target,
     :short => "-t TARGET",
     :long => "--target TARGET",
     :description => "The graphite metric name. Can include * to query multiple metrics",
     :proc => proc {|p| p.to_s },
     :required => true
+
   option :warn,
     :short => "-w WARN",
     :long => "--warn WARN",
     :description => "Warning level",
     :proc => proc {|p| p.to_f },
     :required => false
+
   option :crit,
     :short => "-c Crit",
     :long => "--crit CRIT",


### PR DESCRIPTION
For all of you too lazy to read the file header, here's a copy of what this plugin does:

Checks metrics in graphite, averaged over a period of time. Multiple stats will be checked if \* are used in the "target" query.

The fired sensu event will only be critical if a stat is above the critical threshold. Otherwise, the event will be warning, if a stat is above the warning threshold.
