### PR TITLE
check-stats.rb: fix the issue of nil datapoints

### DIFF
--- a/plugins/graphite/check-stats.rb
+++ b/plugins/graphite/check-stats.rb
@@ -64,7 +64,7 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
   end
 
   def danger(metric)
-    datapoints = metric['datapoints'].collect {|p| p[0].to_f}
+    datapoints = metric['datapoints'].map(&:first).compact
 
     unless datapoints.empty?
       avg = average(datapoints)
@@ -74,6 +74,8 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
       elsif !config[:warn].nil? && avg > config[:warn]
         return [1, "#{metric['target']} is #{avg}"]
       end
+    else
+      return [3, "#{metric['target']} has no datapoints"]
     end
     [0, nil]
   end
@@ -110,6 +112,8 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
       critical message
     elsif status == 1
       warning message
+    elsif status == 3
+      unknown message
     end
     ok
   end


### PR DESCRIPTION
Sometimes Graphite is lagging a bit. When that happens, the last data point in some (or all) metrics collected by this plugin will show as nil.

When calculating the average, nil is treated as zero. That throws the calculation out of balance. I've seen cases where the real metric was just a tiny bit over the threshold, yet it would not trigger the warning because the average was lowered by nil data points. I've had instances when that would continue for a long time, effectively masking the warning or the critical condition for up to 30 minutes, which is unacceptable.

For that reason, in the danger() function I've changed datapoints = metric['datapoints'].blah to throw out the nil points. Then the nil points are not artificially lowering the average anymore.

That's the first part of the diff.

The 2nd and 3rd part of the diff are related to the situation when all datapoints (not just the last one) in a metric are nil. In that case, the true status of this plugin is 'unknown', because that's what it is - we don't have any actual data points (they're all nil, which means missing data), so we acknowledge the 'unknown' status.
