### PR TITLE
Add configuration parameter to OpsGenie handler.

### DIFF
--- a/handlers/notification/opsgenie.rb
+++ b/handlers/notification/opsgenie.rb
@@ -12,6 +12,12 @@ require "json"
 
 class Opsgenie < Sensu::Handler
 
+  option :json_config,
+         :description => 'Configuration name',
+         :short       => '-j JSONCONFIG',
+         :long        => '--json JSONCONFIG',
+         :default     => 'opsgenie'
+
   def handle
     description = @event['notification'] || [@event['client']['name'], @event['check']['name'], @event['check']['output'].chomp].join(' : ')
     begin
@@ -47,8 +53,8 @@ class Opsgenie < Sensu::Handler
 
   def create_alert(description)
     tags = []
-    tags << settings["opsgenie"]["tags"] if settings["opsgenie"]["tags"]
-    tags << "OverwriteQuietHours" if event_status == 2 && settings["opsgenie"]["overwrite_quiet_hours"] == true
+    tags << settings[:json_config]["tags"] if settings[:json_config]["tags"]
+    tags << "OverwriteQuietHours" if event_status == 2 && settings[:json_config]["overwrite_quiet_hours"] == true
     tags << "unknown" if event_status >= 3
     tags << "critical" if event_status == 2
     tags << "warning" if event_status == 1
@@ -57,11 +63,11 @@ class Opsgenie < Sensu::Handler
   end
 
   def post_to_opsgenie(action = :create, params = {})
-    params["customerKey"] = settings["opsgenie"]["customerKey"]
-    params["recipients"]  = settings["opsgenie"]["recipients"]
+    params["customerKey"] = settings[:json_config]["customerKey"]
+    params["recipients"]  = settings[:json_config]["recipients"]
 
     # override source if specified, default is ip
-    params["source"] = settings["opsgenie"]["source"] if settings["opsgenie"]["source"]
+    params["source"] = settings[:json_config]["source"] if settings[:json_config]["source"]
 
     uripath = (action == :create) ? "" : "close"
     uri = URI.parse("https://api.opsgenie.com/v1/json/alert/#{uripath}")


### PR DESCRIPTION
Ran into the problem of needing two OpsGenie API keys (two integrations with different behaviours) and different tags.

The configuration flag will let you define a handler for multiple OpsGenie settings without duplicating the ruby script (boo hardcoding!).

It's also optional and will default to generic "opsgenie" if not defined.
