### PR TITLE
Add librato handler source setting

### DIFF
--- a/handlers/metrics/librato-metrics.json
+++ b/handlers/metrics/librato-metrics.json
@@ -1,6 +1,7 @@
 {
   "librato": {
     "email": "email@example.com",
-    "api_key": "12345"
+    "api_key": "12345",
+    "use_sensu_client_hostname_as_source": false
   }
 }

--- a/handlers/metrics/librato-metrics.rb
+++ b/handlers/metrics/librato-metrics.rb
@@ -18,7 +18,8 @@ class LibratoMetrics < Sensu::Handler
   end
 
   def handle
-    queue = Librato::Metrics::Queue.new
+    source = settings['librato']['use_sensu_client_hostname_as_source'] ? @event['client']['name'] : nil
+    queue = Librato::Metrics::Queue.new :source => source
     @event['check']['output'].split("\n").each do |line|
       name, value, timestamp = line.split(/\s+/)
       queue.add name => {:measure_time => timestamp.to_i, :value => value.to_f}


### PR DESCRIPTION
Add librato-metrics handler setting to set the sensu client hostname as source when reporting to librato.

Defaults to current behavior unless set
