### PR TITLE
Add Totals to apache-graphite plugin

### DIFF
--- a/plugins/apache/apache-graphite.rb
+++ b/plugins/apache/apache-graphite.rb
@@ -93,6 +93,10 @@ class ApacheMetrics < Sensu::Plugin::Metric::CLI::Graphite
     get_mod_status.split("\n").each do |line|
       name, value = line.split(": ")
       case name
+      when "Total Accesses"
+        stats["total_accesses"] = value.to_i
+      when "Total kBytes"
+        stats["total_kbytes"] = value.to_f
       when "CPULoad"
         stats["cpuload"] = value.to_f * 100
       when "BusyWorkers"


### PR DESCRIPTION
This PR adds two extra metrics to plugin/apache-graphite to ensure that we collect Total Accesses and Total kBytes. In order to support a closer view of requests / second. 

Currently mod_status requests Requests Per Sec at Total Accesses / Uptime which isn't terribly useful. 
With this change, you can graphite Requests Per Sec as a derivative on the running total. 
