### PR TITLE
Return unknown instead of critical if data exceeds allowed age.

### DIFF
--- a/plugins/graphite/check-data.rb
+++ b/plugins/graphite/check-data.rb
@@ -125,7 +125,7 @@ class CheckGraphiteData < Sensu::Plugin::Check::CLI
   # Check the age of the data being processed
   def check_age
     if (Time.now.to_i - @value['end']) > config[:allowed_graphite_age]
-      critical "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
+      unknown "Graphite data age is past allowed threshold (#{config[:allowed_graphite_age]} seconds)"
     end
   end
 


### PR DESCRIPTION
Reverts behaviour accidentally changed in 4c96bc5315de170a5ac671d12659777c40cd25e2
