### PR TITLE
check_http.rb : Size of the response : Fix output

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -212,7 +212,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
       warning "Certificate will expire #{warn_cert_expire}"
     end
 
-    size = res.body.nil? ? '0' : 'res.body.size'
+    size = res.body.nil? ? '0' : res.body.size
 
     case res.code
       when /^2/


### PR DESCRIPTION
Output of check_http.rb return a string for the size of the http response.

./plugins/http/check-http.rb -h tutu.tld -p /
CheckHTTP OK: 200, res.body.size bytes
