### PR TITLE
Limit checks to local drives only

### DIFF
--- a/plugins/windows/check-disk-windows.rb
+++ b/plugins/windows/check-disk-windows.rb
@@ -50,7 +50,7 @@ class CheckDisk < Sensu::Plugin::Check::CLI
     end
 
     def read_wmic
-        `wmic volume list brief`.split("\n").drop(1).each do |line|
+        `wmic volume where DriveType=3 list brief`.split("\n").drop(1).each do |line|
             begin
                 capacity, type, _fs, _avail, label, mnt = line.split
                 next if /\S/ !~ line


### PR DESCRIPTION
Added a where clause to the wmic command that is invoked that limits the volume results to local drives only.
Found the list of DriveTypes from: http://msdn.microsoft.com/en-us/library/aa394173%28v=vs.85%29.aspx
