### PR TITLE
check-iis-current-connections

### DIFF
--- a/plugins/windows/check-iis-current-connections.rb
+++ b/plugins/windows/check-iis-current-connections.rb
@@ -17,10 +17,12 @@ class CheckIisCurrentConnections < Sensu::Plugin::Check::CLI
 
   option :warning,
     :short => '-w WARNING',
+    :proc => proc { |a| a.to_f },
     :default =>  50
 
   option :critical,
     :short => '-c CRITICAL',
+    :proc => proc { |a| a.to_f },
     :default =>  150
 
   option :site,


### PR DESCRIPTION
this plugin is throwing a string to float evaluation error on usage. Fixed config option to convert to float for eval output.
