### PR TITLE
mailer.rb - Fix subject to support custom notifications or basic status.

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -98,7 +98,7 @@ class Mailer < Sensu::Handler
             Occurrences:  #{@event['occurrences']}
             #{playbook}
           BODY
-    if @event['check']['notification'].nil? then
+    if @event['check']['notification'].nil?
       subject = "#{action_to_string} - #{short_name}: #{status_to_string}"
     else
       subject = "#{action_to_string} - #{short_name}: #{@event['check']['notification']}"


### PR DESCRIPTION
This was broken as part of this previous commit: https://github.com/sensu/sensu-community-plugins/commit/18b55f933b54e0d814216c7484a9ef203c91e841
Previously if you had a custom notification defined in your check the subject would include the message.  With the above commit that's now replaced with a simple OK, WARNING, CRITICAL.  So this PR restores the original functionality along with supporting the basic status if there is no notification message set.
