### PR TITLE
Create openvpn-metrics.json

### DIFF
--- a/plugins/openvpn/openvpn-metrics.json
+++ b/plugins/openvpn/openvpn-metrics.json
@@ -1,0 +1,7 @@
+{
+  "openvpn-metrics": {
+    "host": "1.2.3.4",
+    "port": "12345",
+    "service": "main"
+  }
+}


### PR DESCRIPTION
Config file for openvpn-metrics.rb

Should be placed in the Sensu config directory - e.g. /etc/sensu/conf.d/

Overrides options given to the plugin via any other method. Edit as needed.

It is an optional file, so don't install it if you don't need a local override.
