### PR TITLE
add ability to check expiry of certs on disk

### DIFF
--- a/plugins/ssl/check-ssl-cert.rb
+++ b/plugins/ssl/check-ssl-cert.rb
@@ -53,7 +53,7 @@ class CheckSSLCert < Sensu::Plugin::Check::CLI
   end
 
   def ssl_pem_expiry
-    OpenSSL::X509::Certificate.new(File.read config[:pem]).not_after    
+    OpenSSL::X509::Certificate.new(File.read config[:pem]).not_after
   end
 
   def validate_opts


### PR DESCRIPTION
not all SSL certs are exposed via ports, some are client-side certificates submitted for server validation of the client identity rather than client validation of the server. (e.g. apple push notification service). these certs are unlikely to be exposed via a service listening on a port, and instead reside solely on disk.

this PR adds the ability to check these types of certs as well. note that this mode is mutually exclusive with checking a host/port.
