### PR TITLE
Handle race condition

### DIFF
--- a/plugins/chef/check-chef-nodes.rb
+++ b/plugins/chef/check-chef-nodes.rb
@@ -50,7 +50,11 @@ class ChefNodesStatusChecker < Sensu::Plugin::Check::CLI
     nodes = connection.get_rest('/nodes')
     nodes.keys.map do |node_name|
       node = connection.get_rest("/nodes/#{node_name}")
-      { node_name => (Time.now - Time.at(node["ohai_time"])) > config[:critical_timespan].to_i }
+      if node["ohai_time"]
+        { node_name => (Time.now - Time.at(node["ohai_time"])) > config[:critical_timespan].to_i }
+      else
+        { node_name => true }
+      end
     end
   end
 


### PR DESCRIPTION
If you're bootstrapping a node and run into an error where it doesn't finish successfully, you will have `Not checked in` under `Last Check-in`. The node in question will then return `nil` for `node["ohai_time"]`.

I'm making an assumption here that users will want to be alerted/reminded that their `knife bootstrap` failed so they will go ahead and delete the client+node from the chef server or reprovision it.
