### PR TITLE
Update haproxy-metrics.rb

### DIFF
--- a/plugins/haproxy/haproxy-metrics.rb
+++ b/plugins/haproxy/haproxy-metrics.rb
@@ -38,7 +38,7 @@ class HAProxyMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :path,
     :short => "-q STATUSPATH",
     :long => "--statspath STATUSPATH",
-    :description => "HAproxy web stats path",
+    :description => "HAproxy web stats path (the / will be prepended to the STATUSPATH e.g stats)",
     :default => "/"
 
   option :username,


### PR DESCRIPTION
Added some further details regarding the statspath setting, to make it a little clearer.

The / is actually prepended to the STATUSPATH.  The manner in which the other settings work makes this a bit confusing, because the other settings replace the default.  However in the context of statspath setting, it is not replaced but prepended to the resulting variable in line 104.

```
        req = Net::HTTP::Get.new("/#{config[:path]};csv;norefresh")
```

This caused expected failure with a setting of:

```
./haproxy-metrics.rb --scheme stats.`hostname`.haproxy --connect `hostname` --port 8888 --statspath /haproxy_stats
```

Works:

```
./haproxy-metrics.rb --scheme stats.`hostname`.haproxy --connect `hostname` --port 8888 --statspath haproxy_stats
```
