### PR TITLE
Add support for using IAM auth for scheduled event notifications

### DIFF
--- a/plugins/aws/check-instance-events.rb
+++ b/plugins/aws/check-instance-events.rb
@@ -53,8 +53,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
     if config[:use_iam_role].nil?
       aws_config.merge!(
         :access_key_id      => config[:aws_access_key],
-        :secret_access_key  => config[:aws_secret_access_key],
-        :region             => config[:aws_region]
+        :secret_access_key  => config[:aws_secret_access_key]
       )
     end
 


### PR DESCRIPTION
The current plugin requires environment variables or inline auth.  I went ahead and added support for a third option for IAM auth. This is related to #853
