### PR TITLE
Return nil if the line is nil

### DIFF
--- a/plugins/system/proc-status-metrics.rb
+++ b/plugins/system/proc-status-metrics.rb
@@ -90,7 +90,7 @@ class ProcStatus < Sensu::Plugin::Metric::CLI::Graphite
 
     metric_names.each do |m|
       line = proc_status_lines.select { |x| /^#{m}/.match(x) }.first
-      val = line.split("\t")[1].to_i
+      val = line ? line.split("\t")[1].to_i : nil
       out[cmdline.to_s][m] = val
     end
     out


### PR DESCRIPTION
This is to fix an issue where it throws an error is the line is nil. In the original code, if line is nil it will error out saying no method split for NilClass
