### PR TITLE
check-stats.rb - added option to ignore UNKNOWN

### DIFF
--- a/plugins/graphite/check-stats.rb
+++ b/plugins/graphite/check-stats.rb
@@ -56,6 +56,13 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
     :proc => proc {|p| p.to_f },
     :required => false
 
+  option :unknown_ignore,
+    :short => "-u",
+    :long => "--unknown-ignore",
+    :description => "Do nothing for UNKNOWN status (when you wildcard-match a ton of metrics at once and you don't care for a few missing data)",
+    :boolean => true,
+    :default => false
+
   def average(a)
     total = 0
     a.to_a.each {|i| total += i.to_f}
@@ -75,7 +82,7 @@ class CheckGraphiteStat < Sensu::Plugin::Check::CLI
         return [1, "#{metric['target']} is #{avg}"]
       end
     else
-      return [3, "#{metric['target']} has no datapoints"]
+      return [3, "#{metric['target']} has no datapoints"] unless config[:unknown_ignore]
     end
     [0, nil]
   end


### PR DESCRIPTION
If you use check-stats.rb to wildcard-match a ton of metrics at once (like, CPU usage from a whole fleet of instances), sometimes there will be one or two instances that are missing data for various reasons. That will throw the whole check into status UNKNOWN, whether you care about those stragglers or you don't.

I've added option -u or --unknown-ignore to let the plugin ignore those few metrics with an UNKNOWN status, and return proper status for everyone else.

If you don't use -u, you get the old behavior.
