### PR TITLE
include "waiting" status in accepted monitored states

### DIFF
--- a/plugins/monit/check-monit-status.rb
+++ b/plugins/monit/check-monit-status.rb
@@ -60,7 +60,7 @@ class CheckMonit < Sensu::Plugin::Check::CLI
 
       next if ignored.include? name
 
-      unless monitored == '1'
+      unless %w( 1 5 ).include? monitored
         unknown "#{name} status unkown"
       end
 


### PR DESCRIPTION
fixes an issue with the check issuing 'unknown' when using the 'every' configuration option in a monit check, causing the appearance of a flapping service.
