### PR TITLE
add check-unicorn-queue plugin

### DIFF
--- a/plugins/unicorn/check-unicorn-queue.rb
+++ b/plugins/unicorn/check-unicorn-queue.rb
@@ -30,7 +30,6 @@ require 'sensu-plugin/check/cli'
 require 'raindrops'
 
 class CheckUnicornQueue < Sensu::Plugin::Check::CLI
-
   option :addr,
     :short => '-a address',
     :description => 'tcp address and port (e.g. 127.0.0.1:8080)'


### PR DESCRIPTION
adds a check for alerting on the length of the unicorn socket's queue
