### PR TITLE
Change statistic_type of HealthyHostCount and UnHealthyHostCount

### DIFF
--- a/plugins/aws/elb-full-metrics.rb
+++ b/plugins/aws/elb-full-metrics.rb
@@ -85,8 +85,8 @@ class ELBMetrics < Sensu::Plugin::Metric::CLI::Graphite
     statistic_type = {
       'Latency' => 'Average',
       'RequestCount' => 'Sum',
-      'UnHealthyHostCount' => 'Sum',
-      'HealthyHostCount' => 'Sum',
+      'UnHealthyHostCount' => 'Average',
+      'HealthyHostCount' => 'Average',
       'HTTPCode_Backend_2XX' => 'Sum',
       'HTTPCode_Backend_4XX' => 'Sum',
       'HTTPCode_Backend_5XX' => 'Sum',


### PR DESCRIPTION
Hi

Change statistic_type of HealthyHostCount and UnHealthyHostCount.
Recommended HealthyHostCount and UnHealthyHostCount is [written](http://docs.aws.amazon.com/ElasticLoadBalancing/latest/DeveloperGuide/US_MonitoringLoadBalancerWithCW.html) as Average.

Please confirm.
Thank you.