### PR TITLE
Fixed bug in Windows where check-log.rb tries to join two paths together...

### DIFF
--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -134,9 +134,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
       @log = File.open(log_file)
     end
 
-    puts File.expand_path(log_file)
     @state_file = File.join(state_dir, File.expand_path(log_file).sub(/^([A-Z]):\//, '\1/'))
-    puts @state_file
     @bytes_to_skip = begin
       File.open(@state_file) do |file|
         file.readline.to_i

--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -134,7 +134,9 @@ class CheckLog < Sensu::Plugin::Check::CLI
       @log = File.open(log_file)
     end
 
-    @state_file = File.join(state_dir, File.expand_path(log_file).sub(/^([A-Z]):/, '\1'))
+    puts File.expand_path(log_file)
+    @state_file = File.join(state_dir, File.expand_path(log_file).sub(/^([A-Z]):\//, '\1/'))
+    puts @state_file
     @bytes_to_skip = begin
       File.open(@state_file) do |file|
         file.readline.to_i

--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -134,7 +134,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
       @log = File.open(log_file)
     end
 
-    @state_file = File.join(state_dir, File.expand_path(log_file))
+    @state_file = File.join(state_dir, File.expand_path(log_file).sub(/^([A-Z]):/, '\1'))
     @bytes_to_skip = begin
       File.open(@state_file) do |file|
         file.readline.to_i


### PR DESCRIPTION
...resulting in a path like 'C:\foo\C:\bar'  Removed the ':' in the 2nd path, so the
result is 'C:\foo\C\bar'