### PR TITLE
Added option to also gather the 'Name' tag for each instance with events

### DIFF
--- a/plugins/aws/check-instance-events.rb
+++ b/plugins/aws/check-instance-events.rb
@@ -83,8 +83,8 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
         rescue Exception => e
           puts "Issue getting instance details for #{id}.  Exception = #{e}"
         end
-         # Pushes 'name(i-xxx)' if the Name tag was found, else it just pushes the id
-         event_instances_with_names << (name == "" ? id : "#{name}(#{id})")
+        # Pushes 'name(i-xxx)' if the Name tag was found, else it just pushes the id
+        event_instances_with_names << (name == "" ? id : "#{name}(#{id})")
       end
       event_instances = event_instances_with_names
     end


### PR DESCRIPTION
I added an option flag `-n` which is defaulted to `false`, but when set to `true` the check script will attempt to gather the `Name` tag for the instances with events and show the `Name` in the check's output
