### PR TITLE
Fix check-procs plugin

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -165,7 +165,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
 
   def on_cygwin?
     # #YELLOW
-    `ps -W 2>&1`; $CHILD_STATUS.exitstatus == 0 # rubocop:disable Semicolon
+    `ps -W 2>&1`; $?.exitstatus == 0 # rubocop:disable Semicolon
   end
 
   def acquire_procs


### PR DESCRIPTION
Was pretty fun to see all my servers blow up from this.

There are (2) ways to go about this.  Either return to using $? and deal with or stop rubocop from complaining about it (I prefer this method) or require 'English' since that is a dependency to use $CHILD_STATUS: http://www.ruby-doc.org/stdlib-2.0/libdoc/English/rdoc/English.html
