### PR TITLE
Add process restart check

### DIFF
--- a/plugins/system/check-process-restart.rb
+++ b/plugins/system/check-process-restart.rb
@@ -59,7 +59,7 @@ class CheckProcessRestart < Sensu::Plugin::Check::CLI
   # Check if we can run checkrestart script
   # Return: Boolean
   def checkrestart?
-    File.exists?('/etc/debian_version') && File.exists?(CHECK_RESTART)
+    File.exist?('/etc/debian_version') && File.exist?(CHECK_RESTART)
   end
 
   # Run checkrestart and parse process(es) and pid(s)


### PR DESCRIPTION
This sensu check is used to check if a running process requires a
restart if a library/package has been changed. This is useful you auto
upgrade pacakages and need to know which services need to be restarted
as a result of the upgrade. The default is to Warn if a single process
needs to be restarted and Critical if 2 or more processes need to be restarted.

The implementation of this check makes it Debian specific and will not work on other
distributions/OS. It also requires passworless sudo for the Sensu user.
