### PR TITLE
Ensure the metrics come in as an array

### DIFF
--- a/handlers/metrics/influxdb-metrics.rb
+++ b/handlers/metrics/influxdb-metrics.rb
@@ -20,7 +20,7 @@ class SensuToInfluxDB < Sensu::Handler
                                                       port: influxdb_port,
                                                       server: influxdb_server
     mydata = []
-    Array(@event['check']['output']).each do |metric|
+    @event['check']['output'].each_line do |metric|
       m = metric.split
       next unless m.count == 3
       key = m[0].split('.', 2)[1]

--- a/handlers/metrics/influxdb-metrics.rb
+++ b/handlers/metrics/influxdb-metrics.rb
@@ -20,7 +20,7 @@ class SensuToInfluxDB < Sensu::Handler
                                                       port: influxdb_port,
                                                       server: influxdb_server
     mydata = []
-    @event['check']['output'].each do |metric|
+    Array(@event['check']['output']).each do |metric|
       m = metric.split
       next unless m.count == 3
       key = m[0].split('.', 2)[1]

--- a/handlers/metrics/influxdb-metrics.rb
+++ b/handlers/metrics/influxdb-metrics.rb
@@ -24,6 +24,7 @@ class SensuToInfluxDB < Sensu::Handler
       m = metric.split
       next unless m.count == 3
       key = m[0].split('.', 2)[1]
+      next unless key
       key.gsub!('.', '_')
       value = m[1].to_f
       mydata = { host: @event['client']['name'], value: value,


### PR DESCRIPTION
I had an issue where `@event['check']['output']` was a string value.  I don't know if this is always the case, or just for the `cpu_usage` metric I am trying out, but coercing it to be an array fixed the issue for me.  This should have no effect if the metrics are already an array.