### PR TITLE
Bugfix: All plugins using CHILD_STATUS require 'English'

### DIFF
--- a/plugins/ceph/check-ceph.rb
+++ b/plugins/ceph/check-ceph.rb
@@ -40,6 +40,7 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'timeout'
+require 'English'
 
 class CheckCephHealth < Sensu::Plugin::Check::CLI
   option :keyring,

--- a/plugins/cucumber/check-cucumber.rb
+++ b/plugins/cucumber/check-cucumber.rb
@@ -32,6 +32,7 @@ require 'timeout'
 require 'json'
 require 'yaml'
 require 'socket'
+require 'English'
 
 class CheckCucumber < Sensu::Plugin::Check::CLI
   OK = 0

--- a/plugins/java/java-permgen.rb
+++ b/plugins/java/java-permgen.rb
@@ -27,6 +27,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
+require 'English'
 
 class CheckJavaPermGen < Sensu::Plugin::Check::CLI
   check_name 'Java PermGen'

--- a/plugins/processes/check-cmd.rb
+++ b/plugins/processes/check-cmd.rb
@@ -10,6 +10,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
+require 'English'
 
 class CheckCMDStatus < Sensu::Plugin::Check::CLI
   option :command,

--- a/plugins/raid/check-megaraid_sas-status.rb
+++ b/plugins/raid/check-megaraid_sas-status.rb
@@ -15,6 +15,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
+require 'English'
 
 class CheckMegraRAID < Sensu::Plugin::Check::CLI
   option :megaraidcmd,

--- a/plugins/system/check-process-restart.rb
+++ b/plugins/system/check-process-restart.rb
@@ -38,6 +38,7 @@
 require 'sensu-plugin/check/cli'
 require 'json'
 require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'English'
 
 # Use to see if any processes require a restart
 class CheckProcessRestart < Sensu::Plugin::Check::CLI


### PR DESCRIPTION
$? works without require English however, CHILD_STATUS needs it and throws an exception unless it is specifically required. Rubocop suggests using CHILD_STATUS over $?. Similar issue is detailed here: https://github.com/bbatsov/rubocop/issues/854

Either we should require English in all relevant plugins or, we should revert back to $?.
 This can be tested as follows in test.rb:
```
stdout = `ls -ltr`
puts ($CHILD_STATUS.exitstatus.to_s)
```
gives:
```
test.rb:4:in `<main>': undefined method `exitstatus' for nil:NilClass (NoMethodError)
```
Adding ``` Require 'English' ``` gives:
```
ruby test.rb
0
```
Also has the same behaviour as require English if you add replace CHILD_STATUS with $?




