### PR TITLE
Require 'English' for $LAST_MATCH_INFO

### DIFF
--- a/handlers/remediation/sensu.rb
+++ b/handlers/remediation/sensu.rb
@@ -73,6 +73,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
+require 'English'
 
 class Remediator < Sensu::Handler
   # Override filter_repeated from Sensu::Handler.


### PR DESCRIPTION
Using `$LAST_MATCH_INFO` without requiring the English lib returns nil.

Somewhat related with #945 :smile: 