### PR TITLE
Add requirements list to check-memory-pcnt.sh

### DIFF
--- a/plugins/system/check-memory-pcnt.sh
+++ b/plugins/system/check-memory-pcnt.sh
@@ -2,12 +2,17 @@
 #
 # Evaluate free system memory from Linux based systems based on percentage
 # This was forked from Sensu Community Plugins
+#
+# Requires: bc
+#
 # Date: 2007-11-12
 # Author: Thomas Borger - ESG
 # Date: 2012-04-02
 # Modified: Norman Harman - norman.harman@mutualmobile.com
 # Date: 2013-9-30
 # Modified: Mario Harvey - Zumetrics
+# Date: 2015-01-10
+# Modified Ollie Armstrong <ollie@armstrong.io>
 
 # get arguments
 


### PR DESCRIPTION
Modified the comments at the top of the check-memory-pcnt.sh plugin to state the requirement of bc.

bc is not installed on a default CentOS 6.5 server and without it this check fails with unknown (exit code 3).