### PR TITLE
Fixes and updates for windows checks - new plugin rabbit-mq-node-health.rb

### DIFF
--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -63,7 +63,8 @@ module Sensu
           interval: 10,
           handler: 'graphite',
           add_client_prefix: true,
-          path_prefix: 'system'
+          path_prefix: 'system',
+          prefix_at_start:0
         }
         if settings[:system_profile].is_a?(Hash)
           @options.merge!(settings[:system_profile])
@@ -80,8 +81,9 @@ module Sensu
       def add_metric(*args)
         value = args.pop
         path = []
+        path << options[:path_prefix] if options[:prefix_at_start]
         path << settings[:client][:name] if options[:add_client_prefix]
-        path << options[:path_prefix]
+        path << options[:path_prefix] if ! options[:prefix_at_start]
         path = (path + args).join('.')
         @metrics << [path, value, Time.now.to_i].join(' ')
       end

--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -64,7 +64,7 @@ module Sensu
           handler: 'graphite',
           add_client_prefix: true,
           path_prefix: 'system',
-          prefix_at_start:0
+          prefix_at_start: 0
         }
         if settings[:system_profile].is_a?(Hash)
           @options.merge!(settings[:system_profile])
@@ -83,7 +83,7 @@ module Sensu
         path = []
         path << options[:path_prefix] if options[:prefix_at_start]
         path << settings[:client][:name] if options[:add_client_prefix]
-        path << options[:path_prefix] if ! options[:prefix_at_start]
+        path << options[:path_prefix] unless options[:prefix_at_start]
         path = (path + args).join('.')
         @metrics << [path, value, Time.now.to_i].join(' ')
       end

--- a/extensions/checks/wmi_metrics.rb
+++ b/extensions/checks/wmi_metrics.rb
@@ -66,7 +66,8 @@ module Sensu
           interval: 10,
           handler: 'graphite',
           add_client_prefix: true,
-          path_prefix: 'WMI'
+          path_prefix: 'WMI',
+          prefix_at_start:0
         }
         if settings[:wmi_metrics].is_a?(Hash)
           @options.merge!(settings[:wmi_metrics])
@@ -83,8 +84,9 @@ module Sensu
       def add_metric(*args)
         value = args.pop
         path = []
+        path << options[:path_prefix] if options[:prefix_at_start]
         path << settings[:client][:name] if options[:add_client_prefix]
-        path << options[:path_prefix]
+        path << options[:path_prefix] if ! options[:prefix_at_start]
         path = (path + args).join('.')
         @metrics << [path, value, Time.now.to_i].join(' ')
       end

--- a/extensions/checks/wmi_metrics.rb
+++ b/extensions/checks/wmi_metrics.rb
@@ -67,7 +67,7 @@ module Sensu
           handler: 'graphite',
           add_client_prefix: true,
           path_prefix: 'WMI',
-          prefix_at_start:0
+          prefix_at_start: 0
         }
         if settings[:wmi_metrics].is_a?(Hash)
           @options.merge!(settings[:wmi_metrics])

--- a/extensions/checks/wmi_metrics.rb
+++ b/extensions/checks/wmi_metrics.rb
@@ -86,7 +86,7 @@ module Sensu
         path = []
         path << options[:path_prefix] if options[:prefix_at_start]
         path << settings[:client][:name] if options[:add_client_prefix]
-        path << options[:path_prefix] if ! options[:prefix_at_start]
+        path << options[:path_prefix] unless options[:prefix_at_start]
         path = (path + args).join('.')
         @metrics << [path, value, Time.now.to_i].join(' ')
       end

--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -115,19 +115,13 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
     es_version = Gem::Version.new(acquire_es_version)
 
-    if (es_version >= Gem::Version.new('1.0.0'))
-      stats_query_array = [
-        'indices',
-        'http',
-        'network',
-        'transport',
-        'thread_pool'
-      ]
+    if es_version >= Gem::Version.new('1.0.0')
+      stats_query_array = %w(indices http network transport thread_pool)
       stats_query_array.push('jvm') if jvm_stats == true
       stats_query_array.push('os') if os_stat == true
       stats_query_array.push('process') if process_stats == true
       stats_query_array.push('tp_stats') if tp_stats == true
-      stats_query_string = stats_query_array.join(',');
+      stats_query_string = stats_query_array.join(',')
     else
       stats_query_string = [
         'clear=true',

--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -123,10 +123,10 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
         'transport',
         'thread_pool'
       ]
-      stats_query_array.add('jvm') if jvm_stats == true
-      stats_query_array.add('os') if os_stat == true
-      stats_query_array.add('process') if process_stats == true
-      stats_query_array.add('tp_stats') if tp_stats == true
+      stats_query_array.push('jvm') if jvm_stats == true
+      stats_query_array.push('os') if os_stat == true
+      stats_query_array.push('process') if process_stats == true
+      stats_query_array.push('tp_stats') if tp_stats == true
       stats_query_string = stats_query_array.join(',');
     else
       stats_query_string = [

--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -123,10 +123,10 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
         'transport',
         'thread_pool'
       ]
-      stats_query_array.add('jvm') if #{jvm_stats} == true
-      stats_query_array.add('os') if #{os_stat} == true
-      stats_query_array.add('process') if #{process_stats} == true
-      stats_query_array.add('tp_stats') if #{tp_stats} == true
+      stats_query_array.add('jvm') if jvm_stats == true
+      stats_query_array.add('os') if os_stat == true
+      stats_query_array.add('process') if process_stats == true
+      stats_query_array.add('tp_stats') if tp_stats == true
       stats_query_string = stats_query_array.join(',');
     else
       stats_query_string = [

--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -113,18 +113,35 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     jvm_stats = !config[:disable_jvm_stats]
     tp_stats = !config[:disable_thread_pool_stats]
 
-    stats_query_string = [
-      'clear=true',
-      'indices=true',
-      'http=true',
-      "jvm=#{jvm_stats}",
-      'network=true',
-      "os=#{os_stat}",
-      "process=#{process_stats}",
-      "thread_pool=#{tp_stats}",
-      'transport=true',
-      'thread_pool=true'
-    ].join('&')
+    es_version = Gem::Version.new(acquire_es_version)
+
+    if (es_version >= Gem::Version.new('1.0.0'))
+      stats_query_array = [
+        'indices',
+        'http',
+        'network',
+        'transport',
+        'thread_pool'
+      ]
+      stats_query_array.add('jvm') if #{jvm_stats} == true
+      stats_query_array.add('os') if #{os_stat} == true
+      stats_query_array.add('process') if #{process_stats} == true
+      stats_query_array.add('tp_stats') if #{tp_stats} == true
+      stats_query_string = stats_query_array.join(',');
+    else
+      stats_query_string = [
+        'clear=true',
+        'indices=true',
+        'http=true',
+        "jvm=#{jvm_stats}",
+        'network=true',
+        "os=#{os_stat}",
+        "process=#{process_stats}",
+        "thread_pool=#{tp_stats}",
+        'transport=true',
+        'thread_pool=true'
+      ].join('&')
+    end
 
     if Gem::Version.new(acquire_es_version) >= Gem::Version.new('1.0.0')
       stats = get_es_resource("_nodes/_local/stats?#{stats_query_string}")

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -91,7 +91,7 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
       nodeinfo = JSON.parse(resource.get)[0]
 
       # Determine % memory consumed
-      pmem = sprintf( '%.2f', nodeinfo['mem_used'].fdiv(nodeinfo['mem_limit']) * 100)
+      pmem = sprintf('%.2f', nodeinfo['mem_used'].fdiv(nodeinfo['mem_limit']) * 100)
 
       # build status and message
       status = 'ok'

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -5,7 +5,7 @@
 #
 # This plugin checks if RabbitMQ server node is in a running state.
 #
-# The plugin is based on the RabbitMQ cluster node healt plugin by Tim Smith
+# The plugin is based on the RabbitMQ cluster node health plugin by Tim Smith
 #
 #
 # Copyright 2012 Abhijith G <abhi@runa.com> and Runa Inc.
@@ -52,18 +52,18 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
          proc: proc(&:to_f),
          default: 80
 
-   option :memcrit,
+  option :memcrit,
          description: 'Critical % of mem usage vs high watermark',
          short: '-c',
          long: '--mcrit PERCENT',
          proc: proc(&:to_f),
          default: 90
 
-    option :watchalarms,
-        description: 'Sound critical if one or more alarms are triggered',
-        short: '-a BOOLEAN',
-        long: '--alarms BOOLEAN',
-        default: 'true'
+  option :watchalarms,
+         description: 'Sound critical if one or more alarms are triggered',
+         short: '-a BOOLEAN',
+         long: '--alarms BOOLEAN',
+         default: 'true'
 
   def run
     res = node_healthy?
@@ -91,26 +91,26 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
       nodeinfo = JSON.parse(resource.get)[0]
 
       # Determine % memory consumed
-      pmem = ( '%.2f' % ( nodeinfo["mem_used"].fdiv(nodeinfo["mem_limit"]) * 100)).to_f
+      pmem = sprintf( '%.2f', nodeinfo['mem_used'].fdiv(nodeinfo['mem_limit']) * 100)
 
       # build status and message
       status = 'ok'
       message = 'Server is healthy'
-      if pmem >= config[:memcrit]
+      if pmem.to_f >= config[:memcrit]
         message = "Memory usage is critical: #{pmem}%"
         status = 'critical'
-      elsif pmem >= config[:memwarn]
+      elsif pmem.to_f >= config[:memwarn]
         message = "Memory usage is at warning: #{pmem}%"
         status = 'warning'
       end
       # If we are set to watch alarms then watch those and set status and messages accordingly
       if config[:watchalarms] == 'true'
-        if nodeinfo["mem_alarm"] == true
+        if nodeinfo['mem_alarm'] == true
           status = 'critical'
           message += ' Memory Alarm ON'
         end
 
-        if nodeinfo["disk_free_alarm"] == true
+        if nodeinfo['disk_free_alarm'] == true
           status = 'critical'
           message += ' Disk Alarm ON'
         end

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -59,9 +59,9 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
 
     option :watchalarms,
         description: 'Sound critical if one or more alarms are triggered',
-        short: '-a',
-        long: '--alarms BOOL',
-        default: true
+        short: '-a BOOLEAN',
+        long: '--alarms BOOLEAN',
+        default: 'true'
 
   def run
     res = node_healthy?
@@ -92,7 +92,7 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
       # build status and message
       status = 'ok'
       message = 'Server is healthy'
-      if  pmem >= config[:memcrit]
+      if pmem >= config[:memcrit]
         message = "Memory usage is critical: #{pmem}%"
         status = 'critical'
       elsif pemem >= config[:memwarn]
@@ -100,13 +100,14 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
         status = 'warning'
       end
       # If we are set to watch alarms then watch those and set status and messages accordingly
-      if config[:watchalarms]?
+      if config[:watchalarms] == 'true'
         if nodeinfo["mem_alarm"] == true
           status = 'critical'
           message += ' Memory Alarm ON'
         end
+
         if nodeinfo["disk_alarm"] == true
-          stats = 'critical'
+          status = 'critical'
           message += ' Disk Alarm ON'
         end
       end

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -89,8 +89,6 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
       # Determine % memory consumed
       pmem = ( '%.2f' % ( nodeinfo["mem_used"].fdiv(nodeinfo["mem_limit"]) * 100)).to_f
 
-      if config[:watchalarms]?
-
       # build status and message
       status = 'ok'
       message = 'Server is healthy'

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -49,13 +49,15 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
          description: 'Warning % of mem usage vs high watermark',
          short: '-m',
          long: '--mwarn PERCENT',
-         default: '80'
+         proc: proc(&:to_f),
+         default: 80
 
    option :memcrit,
          description: 'Critical % of mem usage vs high watermark',
          short: '-c',
          long: '--mcrit PERCENT',
-         default: '90'
+         proc: proc(&:to_f),
+         default: 90
 
     option :watchalarms,
         description: 'Sound critical if one or more alarms are triggered',

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -70,6 +70,8 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
 
     if res['status'] == 'ok'
       ok res['message']
+    elsif res['status'] == 'warning'
+      warning res['message']
     elsif res['status'] == 'critical'
       critical res['message']
     else
@@ -108,7 +110,7 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
           message += ' Memory Alarm ON'
         end
 
-        if nodeinfo["disk_alarm"] == true
+        if nodeinfo["disk_free_alarm"] == true
           status = 'critical'
           message += ' Disk Alarm ON'
         end

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -97,7 +97,7 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
       if pmem >= config[:memcrit]
         message = "Memory usage is critical: #{pmem}%"
         status = 'critical'
-      elsif pemem >= config[:memwarn]
+      elsif pmem >= config[:memwarn]
         message = "Memory usage is at warning: #{pmem}%"
         status = 'warning'
       end

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -1,0 +1,123 @@
+#!/usr/bin/env ruby
+#
+# RabbitMQ check node health plugin
+# ===
+#
+# This plugin checks if RabbitMQ server node is in a running state.
+#
+# The plugin is based on the RabbitMQ cluster node healt plugin by Tim Smith
+#
+#
+# Copyright 2012 Abhijith G <abhi@runa.com> and Runa Inc.
+# Copyright 2014 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
+# Copyright 2015 Edward McLain <ed@edmclain.com> and Daxko, LLC.
+#
+# Released under the same terms as Sensu (the MIT license); see LICENSE
+# for details.
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'json'
+require 'rest_client'
+
+class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
+  option :host,
+         description: 'RabbitMQ host',
+         short: '-w',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :username,
+         description: 'RabbitMQ username',
+         short: '-u',
+         long: '--username USERNAME',
+         default: 'guest'
+
+  option :password,
+         description: 'RabbitMQ password',
+         short: '-p',
+         long: '--password PASSWORD',
+         default: 'guest'
+
+  option :port,
+         description: 'RabbitMQ API port',
+         short: '-P',
+         long: '--port PORT',
+         default: '15672'
+
+  option :memwarn,
+         description: 'Warning % of mem usage vs high watermark',
+         short: '-m',
+         long: '--mwarn PERCENT',
+         default: '80'
+
+   option :memcrit,
+         description: 'Critical % of mem usage vs high watermark',
+         short: '-c',
+         long: '--mcrit PERCENT',
+         default: '90'
+
+    option :watchalarms,
+        description: 'Sound critical if one or more alarms are triggered',
+        short: '-a',
+        long: '--alarms BOOL',
+        default: true
+
+  def run
+    res = node_healthy?
+
+    if res['status'] == 'ok'
+      ok res['message']
+    elsif res['status'] == 'critical'
+      critical res['message']
+    else
+      unknown res['message']
+    end
+  end
+
+  def node_healthy?
+    host     = config[:host]
+    port     = config[:port]
+    username = config[:username]
+    password = config[:password]
+
+    begin
+      resource = RestClient::Resource.new "http://#{host}:#{port}/api/nodes", username, password
+      # Parse our json data
+      nodeinfo = JSON.parse(resource.get)[0]
+
+      # Determine % memory consumed
+      pmem = ( '%.2f' % ( nodeinfo["mem_used"].fdiv(nodeinfo["mem_limit"]) * 100)).to_f
+
+      if config[:watchalarms]?
+
+      # build status and message
+      status = 'ok'
+      message = 'Server is healthy'
+      if  pmem >= config[:memcrit]
+        message = "Memory usage is critical: #{pmem}%"
+        status = 'critical'
+      elsif pemem >= config[:memwarn]
+        message = "Memory usage is at warning: #{pmem}%"
+        status = 'warning'
+      end
+      # If we are set to watch alarms then watch those and set status and messages accordingly
+      if config[:watchalarms]?
+        if nodeinfo["mem_alarm"] == true
+          status = 'critical'
+          message += ' Memory Alarm ON'
+        end
+        if nodeinfo["disk_alarm"] == true
+          stats = 'critical'
+          message += ' Disk Alarm ON'
+        end
+      end
+
+      { 'status' => status, 'message' => message }
+    rescue Errno::ECONNREFUSED => e
+      { 'status' => 'critical', 'message' => e.message }
+    rescue => e
+      { 'status' => 'unknown', 'message' => e.message }
+    end
+  end
+end

--- a/plugins/windows/check-service-windows.rb
+++ b/plugins/windows/check-service-windows.rb
@@ -32,7 +32,7 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 
-class CheckDatabase < Sensu::Plugin::Check::CLI
+class CheckWinService < Sensu::Plugin::Check::CLI
   option :service,
          description: 'Check for a specific service',
          long: '--service SERVICE',

--- a/plugins/windows/check-windows-cpu-load.rb
+++ b/plugins/windows/check-windows-cpu-load.rb
@@ -16,11 +16,13 @@ require 'sensu-plugin/check/cli'
 class CheckWindowsCpuLoad < Sensu::Plugin::Check::CLI
   option :warning,
          short: '-w WARNING',
-         default: 85
+         default: 85,
+         proc: proc(&:to_i)
 
   option :critical,
          short: '-c CRITICAL',
-         default: 95
+         default: 95,
+         proc: proc(&:to_i)
 
   def run
     io = IO.popen("typeperf -sc 1 \"processor(_total)\\% processor time\"")

--- a/plugins/windows/iis-current-connections-metrics.rb
+++ b/plugins/windows/iis-current-connections-metrics.rb
@@ -18,7 +18,7 @@ class IisCurrentConnectionsMetric < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,
          description: 'Metric naming scheme, text to prepend to .$parent.$child',
          long: '--scheme SCHEME',
-         default: "#{Socket.gethostname}.iis_current_connetcions"
+         default: "#{Socket.gethostname}.iis_current_connections"
 
   option :site,
          short: '-s sitename',
@@ -29,5 +29,6 @@ class IisCurrentConnectionsMetric < Sensu::Plugin::Metric::CLI::Graphite
     current_connection = io.readlines[2].split(',')[1].gsub(/"/, '').to_f
 
     output [config[:scheme], config[:site]].join('.'), current_connection
+    ok
   end
 end

--- a/plugins/windows/iis-current-connections-metrics.rb
+++ b/plugins/windows/iis-current-connections-metrics.rb
@@ -43,7 +43,7 @@ class IisCurrentConnectionsMetric < Sensu::Plugin::Metric::CLI::Graphite
     io = IO.popen("typeperf -sc 1 \"Web Service(#{config[:site]})\\Current\ Connections\"")
     current_connection = io.readlines[2].split(',')[1].gsub(/"/, '').to_f
 
-    output [config[:scheme], config[:site]].join('.'), current_connection
+    output[config[:scheme], config[:site]].join('.'), current_connection
     ok
   end
 end

--- a/plugins/windows/iis-current-connections-metrics.rb
+++ b/plugins/windows/iis-current-connections-metrics.rb
@@ -43,7 +43,7 @@ class IisCurrentConnectionsMetric < Sensu::Plugin::Metric::CLI::Graphite
     io = IO.popen("typeperf -sc 1 \"Web Service(#{config[:site]})\\Current\ Connections\"")
     current_connection = io.readlines[2].split(',')[1].gsub(/"/, '').to_f
 
-    output[config[:scheme], config[:site]].join('.'), current_connection
+    output [config[:scheme], config[:site]].join('.'), current_connection
     ok
   end
 end

--- a/plugins/windows/iis-get-requests-metrics.rb
+++ b/plugins/windows/iis-get-requests-metrics.rb
@@ -44,5 +44,6 @@ class IisGetRequests < Sensu::Plugin::Metric::CLI::Graphite
     get_requests = io.readlines[2].split(',')[1].gsub(/"/, '').to_f
 
     output [config[:scheme], config[:site]].join('.'), get_requests
+    ok
   end
 end


### PR DESCRIPTION
For the windows wmi_metrics.rb the option was added to put the graphite prefix at the start - default mode is old mode of postfixing the metric name with the prefix.

Added new plugin for checking the health of a RabbitMQ server