### PR TITLE
Add Icecast2 alive check and metrics plugins

### DIFF
--- a/plugins/icecast2/check-icecast2-alive.rb
+++ b/plugins/icecast2/check-icecast2-alive.rb
@@ -82,8 +82,8 @@ class CheckIcecast2Alive < Sensu::Plugin::Check::CLI
     begin
       resource = RestClient::Resource.new "http://#{host}:#{port}/admin/stats", username, password
       status = Crack::XML.parse(resource.get)
-      { 'status' => 'ok', 'message' => 'Icecast2 server is alive' }
-    rescue Errno::ECONNREFUSED =>e
+      { 'status' => 'ok', 'message' => "#{status['server_id']} server is alive." }
+    rescue Errno::ECONNREFUSED => e
       { 'status' => 'critical', 'message' => e.message }
     rescue => e
       { 'status' => 'unknown', 'message' => e.message }

--- a/plugins/icecast2/check-icecast2-alive.rb
+++ b/plugins/icecast2/check-icecast2-alive.rb
@@ -1,0 +1,92 @@
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#   check-icecast2-alive.rb
+#
+# DESCRIPTION:
+#   This plugin checks the the status of the icecast2 Server using the
+#   XML status endpoint normally available on port 8000
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: crack
+#   gem: rest-client
+#
+# USAGE:
+#   ./check-icecast2-alive.rb -u admin -p 12345
+#
+# NOTES:
+#   This plugin requires a username and password with permission to access
+#   the /admin/stats API call in the icecast2 server.
+#
+# LICENSE:
+#   Adam Ashley <aashley@adamashley.name>
+#   Swift Networks
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+require 'crack'
+require 'rest-client'
+
+class CheckIcecast2Alive < Sensu::Plugin::Check::CLI
+  option :host,
+         description: 'icecast2 host',
+         short: '-h',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :username,
+         description: 'icecast2 username',
+         short: '-u',
+         long: '--username USERNAME',
+         required: true
+
+  option :password,
+         description: 'icecast2 password',
+         short: '-p',
+         long: '--password PASSWORD',
+         required: true
+
+  option :port,
+         description: 'RabbitMQ API port',
+         short: '-P',
+         long: '--port PORT',
+         default: '8000'
+
+  def run
+    res = server_alive?
+
+    if res['status'] == 'ok'
+      ok res['message']
+    elsif res['status'] == 'critical'
+      critical res['message']
+    else
+      unknown res['message']
+    end
+  end
+
+  def server_alive?
+    host     = config[:host]
+    port     = config[:port]
+    username = config[:username]
+    password = config[:password]
+
+    begin
+      resource = RestClient::Resource.new "http://#{host}:#{port}/admin/stats", username, password
+      status = Crack::XML.parse(resource.get)
+      { 'status' => 'ok', 'message' => 'Icecast2 server is alive' }
+    rescue Errno::ECONNREFUSED =>e
+      { 'status' => 'critical', 'message' => e.message }
+    rescue => e
+      { 'status' => 'unknown', 'message' => e.message }
+    end
+  end
+end

--- a/plugins/icecast2/icecast2-metrics.rb
+++ b/plugins/icecast2/icecast2-metrics.rb
@@ -1,0 +1,126 @@
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#   icecast2-metrics.rb
+#
+# DESCRIPTION:
+#   This plugin exports the internal stats of an icecast2 server in graphite
+#   format.
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: crack
+#   gem: rest-client
+#
+# USAGE:
+#   ./icecast2-metrics.rb -u admin -p 12345
+#
+# NOTES:
+#   This plugin requires a username and password with permission to access
+#   the /admin/stats API call in the icecast2 server.
+#
+# LICENSE:
+#   Adam Ashley <aashley@adamashley.name>
+#   Swift Networks
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/metric/cli'
+require 'crack'
+require 'rest-client'
+
+class Icecast2Metrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         description: 'icecast2 host',
+         short: '-h',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :username,
+         description: 'icecast2 username',
+         short: '-u',
+         long: '--username USERNAME',
+         required: true
+
+  option :password,
+         description: 'icecast2 password',
+         short: '-p',
+         long: '--password PASSWORD',
+         required: true
+
+  option :port,
+         description: 'RabbitMQ API port',
+         short: '-P',
+         long: '--port PORT',
+         default: '8000'
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: "#{Socket.gethostname}.icecast2"
+
+  def run
+    host     = config[:host]
+    port     = config[:port]
+    username = config[:username]
+    password = config[:password]
+    scheme   = config[:scheme]
+
+    begin
+      resource = RestClient::Resource.new "http://#{host}:#{port}/admin/stats", username, password
+      status = Crack::XML.parse(resource.get)
+
+      %w{
+        clients
+        listeners
+        sources
+        stats
+      }.each do |stat|
+        output "#{scheme}.active.#{stat}", status["icestats"][stat]
+      end
+
+      %w{
+        client_connections
+        connections
+        file_connections
+        listener_connections
+        source_client_connections
+        source_relay_connections
+        source_total_connections
+        stats_connections
+      }.each do |stat|
+        output "#{scheme}.connections.#{stat}", status["icestats"][stat]
+      end
+      status["icestats"]["source"].each do |source|
+        sourceName = source["mount"].gsub(/^\//, '')
+        %w{
+          bitrate
+          listeners
+          slow_listeners
+          total_bytes_read
+          total_bytes_sent
+        }.each do |stat|
+          if source[stat]
+            output "#{scheme}.sources.#{sourceName}.#{stat}", source[stat]
+          else
+            # Some of the stats are not available until someone connects for
+            # the first time. Return 0.
+            output "#{scheme}.sources.#{sourceName}.#{stat}", 0
+          end
+        end
+      end
+      ok
+    rescue => e
+      puts "Error: exception: #{e}"
+      critical
+    end
+  end
+end

--- a/plugins/icecast2/icecast2-metrics.rb
+++ b/plugins/icecast2/icecast2-metrics.rb
@@ -84,7 +84,7 @@ class Icecast2Metrics < Sensu::Plugin::Metric::CLI::Graphite
         sources
         stats
       }.each do |stat|
-        output "#{scheme}.active.#{stat}", status["icestats"][stat]
+        output "#{scheme}.active.#{stat}", status['icestats'][stat]
       end
 
       %w{
@@ -97,10 +97,10 @@ class Icecast2Metrics < Sensu::Plugin::Metric::CLI::Graphite
         source_total_connections
         stats_connections
       }.each do |stat|
-        output "#{scheme}.connections.#{stat}", status["icestats"][stat]
+        output "#{scheme}.connections.#{stat}", status['icestats'][stat]
       end
-      status["icestats"]["source"].each do |source|
-        sourceName = source["mount"].gsub(/^\//, '')
+      status['icestats']['source'].each do |source|
+        source_name = source['mount'].gsub(/^\//, '')
         %w{
           bitrate
           listeners
@@ -109,11 +109,11 @@ class Icecast2Metrics < Sensu::Plugin::Metric::CLI::Graphite
           total_bytes_sent
         }.each do |stat|
           if source[stat]
-            output "#{scheme}.sources.#{sourceName}.#{stat}", source[stat]
+            output "#{scheme}.sources.#{source_name}.#{stat}", source[stat]
           else
             # Some of the stats are not available until someone connects for
             # the first time. Return 0.
-            output "#{scheme}.sources.#{sourceName}.#{stat}", 0
+            output "#{scheme}.sources.#{source_name}.#{stat}", 0
           end
         end
       end


### PR DESCRIPTION
Adds a basic is server alive check and a metrics plugin to pull stats for the server and all registered mount points.