### PR TITLE
Removed mail gem version constraint

### DIFF
--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -16,7 +16,6 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
-gem 'mail', '~> 2.5.4'
 require 'mail'
 require 'timeout'
 


### PR DESCRIPTION
Could not find 'mail' (~> 2.5.4) - did find: [mail-2.6.3] (Gem::LoadError)