### PR TITLE
Fixed bug in check-process.sh

### DIFF
--- a/plugins/system/check-process.sh
+++ b/plugins/system/check-process.sh
@@ -43,7 +43,8 @@ if [ "$hlp" = "yes" ]; then
 fi
 
 if [ ${PROCESS} ]; then
-  ret=`ps aux | grep "${PROCESS}" | grep -v grep | grep -v $0`
+  scriptname=`basename $0`
+  ret=`ps aux | grep "${PROCESS}" | grep -v grep | grep -v $scriptname`
   if [ ! "${ret}" ]; then
     echo "CRITICAL - process ${PROCESS} does not exist"
     exit 2


### PR DESCRIPTION
The `$0` variable refers to the current script with full path. But if the plugin registered without the full path, then it is not properly filtered out. This causes it to report stopped processes as running.