### PR TITLE
Fixed system_profile net metrics array creation

### DIFF
--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -159,21 +159,21 @@ module Sensu
       end
 
       def proc_net_dev_metrics
-        dev_metrics = %w(rxBytes 
-                         rxPackets 
-                         rxErrors 
-                         rxDrops 
-                         rxFifo 
-                         rxFrame 
-                         rxCompressed 
-                         rxMulticast 
-                         txBytes 
-                         txPackets 
-                         txErrors 
-                         txDrops 
-                         txFifo 
-                         txColls 
-                         txCarrier 
+        dev_metrics = %w(rxBytes
+                         rxPackets
+                         rxErrors
+                         rxDrops
+                         rxFifo
+                         rxFrame
+                         rxCompressed
+                         rxMulticast
+                         txBytes
+                         txPackets
+                         txErrors
+                         txDrops
+                         txFifo
+                         txColls
+                         txCarrier
                          txCompressed)
         read_file('/proc/net/dev') do |proc_net_dev|
           proc_net_dev.each_line do |line|

--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -159,21 +159,21 @@ module Sensu
       end
 
       def proc_net_dev_metrics
-        dev_metrics = %w(rxBytes \
-                         rxPackets \
-                         rxErrors \
-                         rxDrops \
-                         rxFifo \
-                         rxFrame \
-                         rxCompressed \
-                         rxMulticast \
-                         txBytes \
-                         txPackets \
-                         txErrors \
-                         txDrops \
-                         txFifo \
-                         txColls \
-                         txCarrier \
+        dev_metrics = %w(rxBytes 
+                         rxPackets 
+                         rxErrors 
+                         rxDrops 
+                         rxFifo 
+                         rxFrame 
+                         rxCompressed 
+                         rxMulticast 
+                         txBytes 
+                         txPackets 
+                         txErrors 
+                         txDrops 
+                         txFifo 
+                         txColls 
+                         txCarrier 
                          txCompressed)
         read_file('/proc/net/dev') do |proc_net_dev|
           proc_net_dev.each_line do |line|


### PR DESCRIPTION
The "\" character is not needed for the array construction. Using this result in an array like the following.
```
["rxBytes", "\nrxPackets", "\nrxErrors", "\nrxDrops", "\nrxFifo", "\nrxFrame", "\nrxCompressed", "\nrxMulticast", "\ntxBytes", "\ntxPackets", "\ntxErrors", "\ntxDrops", "\ntxFifo", "\ntxColls", "\ntxCarrier", "\ntxCompressed"]
```