### PR TITLE
Add df disk type filter option

### DIFF
--- a/plugins/system/disk-usage-metrics.rb
+++ b/plugins/system/disk-usage-metrics.rb
@@ -98,7 +98,7 @@ class DiskUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
     delim = config[:flatten] == true ? '_' : '.'
     if config[:disk_type]
       types = config[:disk_type]
-      type_option = types.map { |type| "-t #{type}"}.join(' ')
+      type_option = types.map { |type| "-t #{type}" }.join(' ')
     else
       type_option = ''
     end

--- a/plugins/system/disk-usage-metrics.rb
+++ b/plugins/system/disk-usage-metrics.rb
@@ -87,7 +87,7 @@ class DiskUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-B BLOCK_SIZE',
          long: '--block-size BLOCK_SIZE',
          default: 'M'
-  
+
   option :disk_type,
          description: 'Disk types (e.g. ext4) to filter (df -t <type> option)',
          short: '-t DISK_TYPE,[DISK_TYPE]',
@@ -98,7 +98,7 @@ class DiskUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
     delim = config[:flatten] == true ? '_' : '.'
     if config[:disk_type]
       types = config[:disk_type]
-      type_option = types.map {|type| "-t #{type}"}.join(" ")
+      type_option = types.map { |type| "-t #{type}"}.join(' ')
     else
       type_option = ''
     end

--- a/plugins/system/disk-usage-metrics.rb
+++ b/plugins/system/disk-usage-metrics.rb
@@ -87,12 +87,24 @@ class DiskUsageMetrics < Sensu::Plugin::Metric::CLI::Graphite
          short: '-B BLOCK_SIZE',
          long: '--block-size BLOCK_SIZE',
          default: 'M'
+  
+  option :disk_type,
+         description: 'Disk types (e.g. ext4) to filter (df -t <type> option)',
+         short: '-t DISK_TYPE,[DISK_TYPE]',
+         long: '--type DISK_TYPE,[DISK_TYPE]',
+         proc: proc { |a| a.split(',') }
 
   def run
     delim = config[:flatten] == true ? '_' : '.'
+    if config[:disk_type]
+      types = config[:disk_type]
+      type_option = types.map {|type| "-t #{type}"}.join(" ")
+    else
+      type_option = ''
+    end
     # Get disk usage from df with used and avail in megabytes
     # #YELLOW
-    `df -PB#{config[:block_size]} #{config[:local] ? '-l' : ''}`.split("\n").drop(1).each do |line| # rubocop:disable Style/Next
+    `df -PB#{config[:block_size]} #{config[:local] ? '-l' : ''} #{type_option}`.split("\n").drop(1).each do |line| # rubocop:disable Style/Next
       _, _, used, avail, used_p, mnt = line.split
 
       unless %r{/sys|/dev|/run}.match(mnt)


### PR DESCRIPTION
Adds an option to filter disk types via df -t <type>, useful when running on Cumulus Linux to avoid df crapping out on /cumulus/switchd