### PR TITLE
Add the ability to only monitor certain redshift clusters

### DIFF
--- a/plugins/aws/check-redshift-events.rb
+++ b/plugins/aws/check-redshift-events.rb
@@ -3,7 +3,7 @@
 # check-redshift-events
 #
 # DESCRIPTION:
-#   This plugin checks redshift clusters for maintenance events
+#   This plugin checks amazon redshift clusters for maintenance events
 #
 # OUTPUT:
 #   plain-text
@@ -16,7 +16,15 @@
 #   gem: sensu-plugin
 #
 # USAGE:
-#   #YELLOW
+#
+#   check for instances in maint in us-east-1:
+#   ./check-redshift-events.rb -a ${your access key} -s ${your secret access key} -r us-east-1
+#
+#   check for maint events on a single instance in us-east-1 (skip others):
+#   ./check-redshift-events.rb -a ${your access key} -s ${your secret access key} -r us-east-1 -i ${your cluster name}
+#
+#   check for maint events on multiple instance in us-east-1 (skip others):
+#   ./check-redshift-events.rb -a ${your access key} -s ${your secret access key} -r us-east-1 -i ${cluster1,cluster2,cluster3}
 #
 # NOTES:
 #
@@ -26,7 +34,6 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'aws-sdk'
 
@@ -49,26 +56,57 @@ class CheckRedshiftEvents < Sensu::Plugin::Check::CLI
          description: 'AWS Region (such as eu-west-1).',
          default: 'us-east-1'
 
-  def run
-    redshift = AWS::Redshift::Client.new(
+  option :instances,
+         short: '-i INSTANCES',
+         long: '--instances INSTANCES',
+         description: 'Comma separated list of instances to check. Defaults to all clusters in the region',
+         proc: proc { |a| a.split(',') },
+         default: []
+
+  # setup a redshift connection using aws-sdk
+  def redshift
+    @redshift ||= AWS::Redshift::Client.new(
       access_key_id: config[:aws_access_key],
       secret_access_key: config[:aws_secret_access_key],
       region: config[:aws_region])
+  end
 
+  # fetch all clusters in the region from AWS
+  def all_clusters
+    @clusters ||= redshift.describe_clusters[:clusters].map { |c| c[:cluster_identifier] }
+  end
+
+  # throw unknown message if the user passed us a missing instance
+  def check_missing_instances(instances)
+    missing_instances = instances.select { |i| !all_clusters.include?(i) }
+    unknown("Passed instance(s): #{missing_instances.join(',')} not found") unless missing_instances.empty?
+  end
+
+  # return an array of clusters that are in maintenance
+  def clusters_in_maint(clusters)
+    maint_clusters = []
+
+    # fetch the last 2 hours of events for each cluster
+    clusters.each do |cluster_name|
+      events_record = redshift.describe_events(start_time: (Time.now - 7200).iso8601, source_type: 'cluster', source_identifier: cluster_name)
+
+      next if events_record[:events].empty?
+
+      # if the last event is a start maint event then the cluster is still in maint
+      maint_clusters.push(cluster_name) if events_record[:events][-1][:event_id] == 'REDSHIFT-EVENT-2003'
+    end
+    maint_clusters
+  end
+
+  def run
     begin
-      # fetch all clusters identifiers
-      clusters = redshift.describe_clusters[:clusters].map { |c| c[:cluster_identifier] }
-      maint_clusters = []
-
-      # fetch the last 2 hours of events for each cluster
-      clusters.each do |cluster_name|
-        events_record = redshift.describe_events(start_time: (Time.now - 7200).iso8601, source_type: 'cluster', source_identifier: cluster_name)
-
-        next if events_record[:events].empty?
-
-        # if the last event is a start maint event then the cluster is still in maint
-        maint_clusters.push(cluster_name) if events_record[:events][-1][:event_id] == 'REDSHIFT-EVENT-2003'
+      # make sure passed instances exist and only check those instances
+      unless config[:instances].empty?
+        check_missing_instances(config[:instances])
+        all_clusters.select! { |c| config[:instances].include?(c) }
       end
+
+      maint_clusters = clusters_in_maint(all_clusters)
     rescue => e
       unknown "An error occurred processing AWS Redshift API: #{e.message}"
     end


### PR DESCRIPTION
Also add usage information and refactor the large amount of code in the run method into individual methods
As an added bonus if the cluster goes away you'll get an alert now since passed in clusters are now checked against those in the region