### PR TITLE
Do not create lock for GPG key check

### DIFF
--- a/plugins/gpg/check-gpg-expiration.rb
+++ b/plugins/gpg/check-gpg-expiration.rb
@@ -77,7 +77,7 @@ class CheckGpgExpire < Sensu::Plugin::Check::CLI
   # Run the GPG command and return the expiration date in epoch
   def key_expire
     return_val = [false, nil]
-    args = ['--with-colons', '--fixed-list-mode', '--list-key', config[:id]]
+    args = ['--with-colons', '--fixed-list-mode', '--lock-never', '--list-key', config[:id]]
     gpg_cmd = config[:homedir].nil? ? [GPG] + args : [GPG, "--homedir #{config[:homedir]}"] + args
     cmd_out, cmd_err, status = Open3.capture3 gpg_cmd.join ' '
     if status.success?


### PR DESCRIPTION
In most cases the sensu client will be as a different user to the one that owns the
GPG home directory and will not have write permissions to the home
directory. As we are only reading keys, we don't need (or want) to
create a lock file. This means we can give read permission to the GPG
homedir without giving write permission.

In future, it might be worth considering adding an option for the user
and using sudo to run the command.

Yasser