### PR TITLE
Force warn and crit string to int

### DIFF
--- a/plugins/gpg/check-gpg-expiration.rb
+++ b/plugins/gpg/check-gpg-expiration.rb
@@ -44,10 +44,12 @@ require 'time'
 class CheckGpgExpire < Sensu::Plugin::Check::CLI
   option :warn,
          short: '-w WARN',
+         proc: proc(&:to_i),
          default: 60
 
   option :crit,
          short: '-c CRIT',
+         proc: proc(&:to_i),
          default: 30
 
   option :homedir,


### PR DESCRIPTION
Numerical comparison fails, so forcing to integer.

Yasser