### PR TITLE
Allow multiple slack configurations

### DIFF
--- a/handlers/notification/slack.json
+++ b/handlers/notification/slack.json
@@ -1,6 +1,7 @@
 {
   "slack": {
     "webhook_url": "webhook url",
+    "channel": "#notifications-room, optional defaults to slack defined",
     "message_prefix": "optional prefix - can be used for mentions",
     "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
     "bot_name": "optional bot name, defaults to slack defined"

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -26,6 +26,10 @@ class Slack < Sensu::Handler
     get_setting('webhook_url')
   end
 
+  def slack_channel
+    get_setting('channel')
+  end
+
   def slack_message_prefix
     get_setting('message_prefix')
   end
@@ -89,6 +93,7 @@ class Slack < Sensu::Handler
         color: color
       }]
     }.tap do |payload|
+      payload[:channel] = slack_channel if slack_channel
       payload[:username] = slack_bot_name if slack_bot_name
     end
   end

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -16,6 +16,12 @@ require 'sensu-handler'
 require 'json'
 
 class Slack < Sensu::Handler
+  option :json_config,
+         description: 'Configuration name',
+         short: '-j JSONCONFIG',
+         long: '--json JSONCONFIG',
+         default: 'slack'
+
   def slack_webhook_url
     get_setting('webhook_url')
   end
@@ -37,7 +43,7 @@ class Slack < Sensu::Handler
   end
 
   def get_setting(name)
-    settings['slack'][name]
+    settings[config[:json_config]][name]
   end
 
   def handle


### PR DESCRIPTION
* Support multiple configurations, following: https://github.com/sensu/sensu-plugin/issues/66
* Revert deletion of channel setting. It is still possible to override the default channel: https://api.slack.com/incoming-webhooks