### PR TITLE
Fix invalid shebang

### DIFF
--- a/plugins/network/check-banner.rb
+++ b/plugins/network/check-banner.rb
@@ -1,4 +1,4 @@
-# !/usr/bin/env ruby
+#! /usr/bin/env ruby
 #
 # Check Banner
 # ===


### PR DESCRIPTION
`check-banner.rb` plugin cause the folloing error because of invalid shebang.

```
sudo /etc/sensu/plugins/check-banner.rb
/etc/sensu/plugins/check-banner.rb: 14: /etc/sensu/plugins/check-banner.rb: cannot open 1.9.0: No such file
/etc/sensu/plugins/check-banner.rb: 14: /etc/sensu/plugins/check-banner.rb: require: not found
/etc/sensu/plugins/check-banner.rb: 15: /etc/sensu/plugins/check-banner.rb: require: not found
/etc/sensu/plugins/check-banner.rb: 16: /etc/sensu/plugins/check-banner.rb: require: not found
/etc/sensu/plugins/check-banner.rb: 17: /etc/sensu/plugins/check-banner.rb: require: not found
/etc/sensu/plugins/check-banner.rb: 19: /etc/sensu/plugins/check-banner.rb: cannot open Sensu::Plugin::Check::CLI: No such file
/etc/sensu/plugins/check-banner.rb: 19: /etc/sensu/plugins/check-banner.rb: class: not found
/etc/sensu/plugins/check-banner.rb: 20: /etc/sensu/plugins/check-banner.rb: option: not found
/etc/sensu/plugins/check-banner.rb: 21: /etc/sensu/plugins/check-banner.rb: short:: not found
/etc/sensu/plugins/check-banner.rb: 22: /etc/sensu/plugins/check-banner.rb: long:: not found
/etc/sensu/plugins/check-banner.rb: 23: /etc/sensu/plugins/check-banner.rb: description:: not found
/etc/sensu/plugins/check-banner.rb: 24: /etc/sensu/plugins/check-banner.rb: default:: not found
/etc/sensu/plugins/check-banner.rb: 26: /etc/sensu/plugins/check-banner.rb: option: not found
/etc/sensu/plugins/check-banner.rb: 27: /etc/sensu/plugins/check-banner.rb: short:: not found
/etc/sensu/plugins/check-banner.rb: 28: /etc/sensu/plugins/check-banner.rb: long:: not found
/etc/sensu/plugins/check-banner.rb: 29: /etc/sensu/plugins/check-banner.rb: Syntax error: "(" unexpected
```