### PR TITLE
Added custom proxy + no proxy support to check http

### DIFF
--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -145,6 +145,16 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   option :response_code,
          long: '--response-code CODE',
          description: 'Check for a specific response code'
+         
+  option :proxy_url,
+         long: '--proxy-url PROXY_URL',
+         description: 'Use a proxy server to connect'
+
+  option :no_proxy,
+         long: '--noproxy',
+         boolean: true,
+         description: 'Do not use proxy server even from environment http_proxy setting',
+         default: false
 
   def run
     if config[:url]
@@ -173,7 +183,17 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   end
 
   def acquire_resource
-    http = Net::HTTP.new(config[:host], config[:port])
+    
+    http = nil
+
+    if config[:no_proxy]
+         http = Net::HTTP.new(config[:host], config[:port], nil, nil)
+    elsif config[:proxy_url]
+         proxy_uri = URI.parse(config[:proxy_url])
+         http = Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
+    else
+       http = Net::HTTP.new(config[:host], config[:port])
+    end
 
     warn_cert_expire = nil
     if config[:ssl]

--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -183,7 +183,6 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   end
 
   def acquire_resource
-
     http = nil
 
     if config[:no_proxy]

--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -145,7 +145,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   option :response_code,
          long: '--response-code CODE',
          description: 'Check for a specific response code'
-         
+
   option :proxy_url,
          long: '--proxy-url PROXY_URL',
          description: 'Use a proxy server to connect'
@@ -183,16 +183,16 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
   end
 
   def acquire_resource
-    
+
     http = nil
 
     if config[:no_proxy]
-         http = Net::HTTP.new(config[:host], config[:port], nil, nil)
+      http = Net::HTTP.new(config[:host], config[:port], nil, nil)
     elsif config[:proxy_url]
-         proxy_uri = URI.parse(config[:proxy_url])
-         http = Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
+      proxy_uri = URI.parse(config[:proxy_url])
+      http = Net::HTTP.new(config[:host], config[:port], proxy_uri.host, proxy_uri.port)
     else
-       http = Net::HTTP.new(config[:host], config[:port])
+      http = Net::HTTP.new(config[:host], config[:port])
     end
 
     warn_cert_expire = nil


### PR DESCRIPTION
The change adds the following support to the check http script.

1) Specify a custom proxy url using the newly introduced "--proxy-url <proxy_url>" option.
2) Choose to not pick the environment http_proxy variable in certain scenarios using the newly introduced "--noproxy" flag.
3) Create an HTTP connection with default env proxy settings if the above 2 are not satisfied.

Specifying a custom proxy host and a proxy port during the Net:HTTP object initialization allows to override the environment http_proxy variable. The Net:HTTP library does not support reading of the "no_proxy" environment variable. However the behavior can be achieved where the request should not go through the proxy server using nil values explicitly specified for proxy_host and proxy_port in the Net:HTTP object initialization. If the object is initialized only using 2 arguments omitting the proxy_host and proxy_port arguments in the method altogether, env "http_proxy" settings are picked up.

Motivation:

1) For no_proxy, the motivation is fairly evident from the fact that there is no inherent support for the "no_proxy" env variable in the Net:HTTP library.
2) For http_proxy, although the Net::HTTP library initializes the http object using the env "http_proxy" settings, it might not be ideal in all scenarios. A classic case is spawning the sensu service using the /sbin/service wrapper on Centos. When using the same, all env variables (except a few standard ones) are ignored to provide a clean environment for the service to start. Now, the checks dependent on the http_proxy variable start failing in such a case as the http_proxy env variable is no longer available inside the service environment. The same is not true while doing a plain "/etc/init.d" invokation to start the service. Here the http_proxy variable gets picked up. Hence, to ensure consistent behavior for checks dependent on proxies, irrespective of the method of invocation, the http_proxy setting could be explicitly specified in the check.

Additional use case:

In addition to the above, there can well be scenarios where a different proxy server (from the environment settings) is required to be hit for certain checks. This change allows to override the environment settings for individual checks, hence making it more flexible.