### PR TITLE
Fix: returns 0 if RMQ queue is new

### DIFF
--- a/plugins/rabbitmq/check-rabbitmq-queue.rb
+++ b/plugins/rabbitmq/check-rabbitmq-queue.rb
@@ -87,6 +87,9 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
       queues.each do |queue|
         if queue['name'] == q
           total = queue['messages']
+          if total == nil
+            total = 0
+          end
           message "#{total}"
           @crit <<  "#{ q }:#{ total }" if total > config[:critical].to_i
           @warn << "#{ q }:#{ total }" if total > config[:warn].to_i


### PR DESCRIPTION
If RMQ queue is new and never had messages, then it will return
null in place of message count and plugin crashes. This fix will return
0 if queue wasn’t used.