### PR TITLE
Added FREE_MEMORY condition for Fedora 21

### DIFF
--- a/plugins/system/check-mem.sh
+++ b/plugins/system/check-mem.sh
@@ -41,7 +41,11 @@ fi
 WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
-FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`
+if [ `awk '{print $3}' /etc/redhat-release` = "21" ]; then
+  FREE_MEMORY=`free -m | grep Mem | awk '{ print $7 }'`
+else
+  FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`
+fi
 
 if [ "$FREE_MEMORY" = "" ]; then
   echo "MEM UNKNOWN -"

--- a/plugins/system/check-mem.sh
+++ b/plugins/system/check-mem.sh
@@ -41,7 +41,7 @@ fi
 WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
-if [ `awk '{print $3}' /etc/redhat-release` = "21" ]; then
+if [ -f /etc/redhat-release ] && [ `awk '{print $3}' /etc/redhat-release` = "21" ]; then
   FREE_MEMORY=`free -m | grep Mem | awk '{ print $7 }'`
 else
   FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`


### PR DESCRIPTION
The free utility provided with F21 doesn't print the buffers/cache line. The Mem line contains all the needed memory info.