### PR TITLE
Fixed iostat-extended-metrics giving the wrong header for values.

### DIFF
--- a/plugins/system/iostat-extended-metrics.rb
+++ b/plugins/system/iostat-extended-metrics.rb
@@ -88,7 +88,8 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
 
       fields = line.split(/\s+/)
 
-      key = fields.shift if stage == :device
+      key = fields.shift
+      key = "avg-cpu" if stage == :cpu
       stats[key] = Hash[headers.zip(fields.map(&:to_f))]
     end
     stats

--- a/plugins/system/iostat-extended-metrics.rb
+++ b/plugins/system/iostat-extended-metrics.rb
@@ -89,7 +89,7 @@ class IOStatExtended < Sensu::Plugin::Metric::CLI::Graphite
       fields = line.split(/\s+/)
 
       key = fields.shift
-      key = "avg-cpu" if stage == :cpu
+      key = 'avg-cpu' if stage == :cpu
       stats[key] = Hash[headers.zip(fields.map(&:to_f))]
     end
     stats


### PR DESCRIPTION
On a typical iostat output like this.

```
Linux 2.6.32-358.23.2.el6.x86_64         02/11/2015      _x86_64_        (8 CPU)

avg-cpu:  %user   %nice %system %iowait  %steal   %idle
           6.03    0.03    4.70    0.43    0.00   88.81

Device:         rrqm/s   wrqm/s     r/s     w/s   rsec/s   wsec/s avgrq-sz avgqu-sz   await  svctm  %util
sda               0.05    31.17    0.47   10.51    36.31   323.95    32.80     0.04    3.30   0.78   0.86
sdb               1.23   245.51    6.43   29.94  1751.01  2203.62   108.74     0.13    3.47   0.82   2.99
sdc               0.34    15.82    1.59    0.65    33.67   131.82    73.94     0.84  377.24   3.01   0.67
```

The avg-cpu information would be given the wrong header, each one shifted to the left. e.g. steal being given the value for idle.