### PR TITLE
Only use SSL if the graphite uri is https

### DIFF
--- a/handlers/notification/graphite_event.rb
+++ b/handlers/notification/graphite_event.rb
@@ -27,7 +27,7 @@ class GraphiteEvent < Sensu::Handler
     uri          = URI.parse(uri)
     req          = Net::HTTP::Post.new(uri.path)
     sock         = Net::HTTP.new(uri.host, uri.port)
-    sock.use_ssl = true
+    sock.use_ssl = true if uri.scheme == 'https'
     req.body     = body
 
     req.basic_auth(uri.user, uri.password) if uri.user


### PR DESCRIPTION
Should probably use Net::HTTPS, but this allows for users to have non-ssl enabled Graphite installations and for the graphite_events to dynamically recognise the protocol to use.