### PR TITLE
Improve graphite-event data and timestamp

### DIFF
--- a/handlers/notification/graphite_event.rb
+++ b/handlers/notification/graphite_event.rb
@@ -62,8 +62,8 @@ class GraphiteEvent < Sensu::Handler
     body = {
       'what' => 'sensu_event',
       'tags' => tags.join(','),
-      'data' => event_status,
-      'when' => Time.now.to_i
+      'data' => @event['check']['output'],
+      'when' => @event['client']['timestamp']
     }
 
     uri = settings['graphite_event']['server_uri']


### PR DESCRIPTION
Use the Output from the check as the content of the data field for the event,
and use the timestamp from the check itself rather than the time the handler
runs - this accounts for delay in executing the handler due to latency, or
rabbitmq message processing.