### PR TITLE
Add incident_key_prefix and description_prefix to PagerDuty handler.

### DIFF
--- a/handlers/notification/pagerduty.rb
+++ b/handlers/notification/pagerduty.rb
@@ -29,14 +29,16 @@ class Pagerduty < Sensu::Handler
     else
       api_key = settings['pagerduty']['api_key']
     end
+    incident_key_prefix = settings['pagerduty']['incident_key_prefix']
+    description_prefix = settings['pagerduty']['description_prefix']
     begin
       timeout(10) do
         response = case @event['action']
                    when 'create'
                      Redphone::Pagerduty.trigger_incident(
                        service_key: api_key,
-                       incident_key: incident_key,
-                       description: event_summary,
+                       incident_key: [incident_key_prefix, incident_key].compact.join(' '),
+                       description: [description_prefix, event_summary].compact.join(' '),
                        details: @event
                      )
                    when 'resolve'


### PR DESCRIPTION
This can be used to specify environment (e.g. prod vs QA).