### PR TITLE
nodetool cfstats output support, post v 2.0

### DIFF
--- a/plugins/cassandra/cassandra-graphite.rb
+++ b/plugins/cassandra/cassandra-graphite.rb
@@ -285,6 +285,9 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   # nodetool -h localhost cfstats
+  #
+  # Pre v 2.0
+  #
   # Keyspace: system
   #   Read Count: 216
   #   Read Latency: 1.4066805555555557 ms.
@@ -315,9 +318,40 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
   #     Compacted row maximum size: 0
   #     Compacted row mean size: 0
   #
+  # Post v 2.0
+  #
+  # Keyspace: system
+  #         Read Count: 1806
+  #         Read Latency: 0.47397231450719823 ms.
+  #         Write Count: 77488
+  #         Write Latency: 0.03966830993186042 ms.
+  #         Pending Tasks: 0
+  #                 Table: IndexInfo
+  #                 SSTable count: 0
+  #                 Space used (live), bytes: 0
+  #                 Space used (total), bytes: 0
+  #                 SSTable Compression Ratio: 0.0
+  #                 Number of keys (estimate): 0
+  #                 Memtable cell count: 0
+  #                 Memtable data size, bytes: 0
+  #                 Memtable switch count: 0
+  #                 Local read count: 0
+  #                 Local read latency: 0.000 ms
+  #                 Local write count: 0
+  #                 Local write latency: 0.000 ms
+  #                 Pending tasks: 0
+  #                 Bloom filter false positives: 0
+  #                 Bloom filter false ratio: 0.00000
+  #                 Bloom filter space used, bytes: 0
+  #                 Compacted partition minimum bytes: 0
+  #                 Compacted partition maximum bytes: 0
+  #                 Compacted partition mean bytes: 0
+  #                 Average live cells per slice (last five minutes): 0.0
+  #                 Average tombstones per slice (last five minutes): 0.0
+  #
   # some notes on parsing cfstats output:
-  # - a line preceeded by 1 tab contains keyspace metrics
-  # - a line preceeded by 2 tabs contains column family metrics
+  # - a line preceded by 1 tab contains keyspace metrics
+  # - a line preceded by 2 tabs contains column family metrics
   def parse_cfstats
     def get_metric(string)
       string.strip!
@@ -345,8 +379,8 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
       num_indents = line.count("\t")
       if m = line.match(/^Keyspace:\s+(\w+)$/)
         keyspace = m[1]
-      elsif m = line.match(/\t\tColumn Family[^:]*:\s+(\w+)$/)
-        cf = m[1]
+      elsif m = line.match(/\t\t(Column Family|Table)[^:]*:\s+(\w+)$/)
+        cf = m[2]
       elsif num_indents == 0
         # keyspace = nil
         cf = nil


### PR DESCRIPTION
This commit adds support to collect 'Table:' metrics from 'nodetool cfstats' output.

Before Cassandra v 2.0, 'Column Family:' was part of the output.