### PR TITLE
Fixes simple whitespace error.

### DIFF
--- a/handlers/notification/ponymailer.rb
+++ b/handlers/notification/ponymailer.rb
@@ -44,14 +44,14 @@ class PonyMailer < Sensu::Handler
       charset: 'utf-8',
       sender: settings['ponymailer']['from']
     }
-    mail_options.merg e!(via_options: {
-                           address: settings['ponymailer']['hostname'],
-                           port: settings['ponymailer']['port'],
-                           enable_starttls_auto: settings['ponymailer']['tls'],
-                           user_name: settings['ponymailer']['username'],
-                           password: settings['ponymailer']['password'],
-                           authentication: :plain
-                         }) if settings['ponymailer']['authenticate']
+    mail_options.merge!(via_options: {
+                          address: settings['ponymailer']['hostname'],
+                          port: settings['ponymailer']['port'],
+                          enable_starttls_auto: settings['ponymailer']['tls'],
+                          user_name: settings['ponymailer']['username'],
+                          password: settings['ponymailer']['password'],
+                          authentication: :plain
+                        }) if settings['ponymailer']['authenticate']
 
     mail_options[:body] = %(Sensu has detected a failed check. Event analysis follows:
 


### PR DESCRIPTION
The error results in an `undefined e! method` due to the space between __merg__ and __e!__.