### PR TITLE
Removes the unused arguments option which results in an error.

### DIFF
--- a/handlers/notification/ponymailer.rb
+++ b/handlers/notification/ponymailer.rb
@@ -35,7 +35,6 @@ class PonyMailer < Sensu::Handler
       subject: "Sensu Monitoring Alert: #{action_to_string} :: #{short_name}",
       from: "#{settings['ponymailer']['fromname']} <#{settings['ponymailer']['from']}>",
       via: :smtp,
-      arguments: '',
       via_options: {
         address: settings['ponymailer']['hostname'],
         port: settings['ponymailer']['port'],


### PR DESCRIPTION
Before removing the arguments option I would get undefined method
arguments for the Mail::Message object.

I'm using the pony gem version 1.11 and mail gem version 2.6.3.