### PR TITLE
Setup office hours mutator to be handle time offsets

### DIFF
--- a/mutators/officehours.rb
+++ b/mutators/officehours.rb
@@ -16,24 +16,26 @@
 #
 # DEPENDENCIES:
 #
-#   json and time Ruby gems
+#   json and time gems
 #
 # Copyright 2013 Jean-Francois Theroux <failshell@gmail.com>
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems'
 require 'json'
 require 'time'
 
 # parse event
 event = JSON.parse(STDIN.read, symbolize_names: true)
 t = Time.now
+start_time = '9:00'
+end_time =  '17:00'
+gmt_offset = '+00:00'
 
 # Verify if we're opened for business
 if t.wday.between?(1, 5)
-  if t.between?(Time.parse('9:00'), Time.parse('17:00'))
+  if t.between?(Time.parse("#{start_time} #{gmt_offset}"), Time.parse("#{end_time} #{gmt_offset}"))
     event.merge!(mutated: true, office_hours: true)
   end
 end


### PR DESCRIPTION
I plan to do additional work to 1) support DST and 2) load the configuration of what you consider office hours from JSON.  This puts the mutator in better shape now though.  Most servers are in GMT and the out of the box setup for this mutator was broken.  With this change all you have to do is change the gmt_offset variable to correctly align your office time vs. your servers time.  Currently this mutator would only work if you worked in GMT.  I also removed the Rubygems require since that's only needed for Ruby 1.8.7 and the removal of hash rockets in the plugins / handlers broke that support anyways.