### PR TITLE
Improvements to the office hours mutator

### DIFF
--- a/mutators/officehours.rb
+++ b/mutators/officehours.rb
@@ -6,7 +6,9 @@
 # DESCRIPTION:
 #   Check if we're at the office or not. To allow handlers to decide if it
 #   should notify or not. For example, don't alert us for development
-#   environments on a Saturday at 4am.
+#   environments on a Saturday at 4am.  Note: Adding this mutator alone
+#   will not prevent notification. Handlers must utilize the office_hours
+#   value to decide if they should notify or not.
 #
 # OUTPUT:
 #   mutated JSON event
@@ -19,23 +21,34 @@
 #   json and time Ruby gems
 #
 # Copyright 2013 Jean-Francois Theroux <failshell@gmail.com>
+# Copyright 2015 Tim Smith <tim@cozy.co>
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems'
 require 'json'
 require 'time'
 
 # parse event
 event = JSON.parse(STDIN.read, symbolize_names: true)
-t = Time.now
+@t = Time.now
+@start_time = '9:00'
+@end_time =  '17:00'
+@gmt_offset = '+0:00'
 
-# Verify if we're opened for business
-if t.wday.between?(1, 5)
-  if t.between?(Time.parse('9:00'), Time.parse('17:00'))
-    event.merge!(mutated: true, office_hours: true)
-  end
+def office_hours?
+  @t.between?(Time.parse("#{@start_time} #{@gmt_offset}"), Time.parse("#{@end_time} #{@gmt_offset}"))
+end
+
+def office_day?
+  @t.wday.between?(1, 5)
+end
+
+# mutate the event based on office hours or not
+if office_day? && office_hours?
+  event.merge!(mutated: true, office_hours: true)
+else
+  event.merge!(mutated: true, office_hours: false)
 end
 
 # output modified event


### PR DESCRIPTION
1) Remove require ruby gems since all plugins have removed hash rockets thus eliminated Ruby 1.8.7 support already
2) Factor out some of the logic into methods to make things easier to read
3) Add support for GMT offsets.  Most servers run in GMT while most offices are not in GMT.  This mutator was really checking if it was office hours where the server was before.  Now you can modify the mutator for you local offset (ex PST is -08:00)
4) The mutator now adds office_hours = false to the event JSON not just office_hours = true.  This gives more useful information for consumption by downstream handlers