### PR TITLE
Improve the formatting of slack notices

### DIFF
--- a/handlers/notification/slack.json
+++ b/handlers/notification/slack.json
@@ -4,6 +4,7 @@
     "channel": "#notifications-room, optional defaults to slack defined",
     "message_prefix": "optional prefix - can be used for mentions",
     "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
-    "bot_name": "optional bot name, defaults to slack defined"
+    "bot_name": "optional bot name, defaults to slack defined",
+    "markdown_enabled": false
   }
 }

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -42,6 +42,10 @@ class Slack < Sensu::Handler
     get_setting('surround')
   end
 
+  def markdown_enabled
+    get_setting('markdown_enabled') || true
+  end
+
   def incident_key
     @event['client']['name'] + '/' + @event['check']['name']
   end
@@ -52,12 +56,12 @@ class Slack < Sensu::Handler
 
   def handle
     description = @event['check']['notification'] || build_description
-    post_data("#{incident_key}: #{description}")
+    post_data("*Check*\n#{incident_key}\n\n*Description*\n#{description}")
   end
 
   def build_description
     [
-      @event['check']['output'],
+      @event['check']['output'].strip,
       @event['client']['address'],
       @event['client']['subscriptions'].join(',')
     ].join(' : ')
@@ -95,6 +99,7 @@ class Slack < Sensu::Handler
     }.tap do |payload|
       payload[:channel] = slack_channel if slack_channel
       payload[:username] = slack_bot_name if slack_bot_name
+      payload[:attachments][0][:mrkdwn_in] = %w(text) if markdown_enabled
     end
   end
 


### PR DESCRIPTION
1) strip the newline off sensu command output that lead to odd formatting
2) Enable markdown by default, but add a new config option markdown_enabled that allows you turn it off if you have markdown like text strings coming back (there's no escape characters for slack markdown)
3) Added bolded headers of "check" and "description"

Old:
![screen shot 2015-02-19 at 5 57 29 pm](https://cloud.githubusercontent.com/assets/1015200/6280672/713b3546-b866-11e4-846e-f58f7d6e52e6.png)

New
![screen shot 2015-02-19 at 5 57 06 pm](https://cloud.githubusercontent.com/assets/1015200/6280673/7524b510-b866-11e4-8a49-defe144738e2.png)
