### PR TITLE
correct path to notification element & correct post format

### DIFF
--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -51,7 +51,7 @@ class Slack < Sensu::Handler
   end
 
   def handle
-    description = @event['notification'] || build_description
+    description = @event['check']['notification'] || build_description
     post_data("#{incident_key}: #{description}")
   end
 
@@ -70,7 +70,7 @@ class Slack < Sensu::Handler
 
     req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}")
     text = slack_surround ? slack_surround + notice + slack_surround : notice
-    req.body = "payload=#{payload(text).to_json}"
+    req.body = payload(text).to_json
 
     response = http.request(req)
     verify_response(response)


### PR DESCRIPTION
I used this handler and encountered two errors:
- the check notification was not put into the description as designed
- the post body was not being sent as json, and thus had issues with sending urls and other text.

This PR corrects both issues. :smile_cat: 