### PR TITLE
Set all aws plugins to depend on aws-sdk-v1 that currently use the aws-sdk gem

### DIFF
--- a/plugins/aws/autoscaling-instance-count-metrics.rb
+++ b/plugins/aws/autoscaling-instance-count-metrics.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -27,7 +27,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1-v1'
 
 class AutoScalingInstanceCountMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :groupname,

--- a/plugins/aws/autoscaling-instance-count-metrics.rb
+++ b/plugins/aws/autoscaling-instance-count-metrics.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk-v1-v1
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -27,7 +27,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk-v1-v1'
+require 'aws-sdk-v1'
 
 class AutoScalingInstanceCountMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :groupname,

--- a/plugins/aws/check-dynamodb-capacity.rb
+++ b/plugins/aws/check-dynamodb-capacity.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: time
 #   gem: sensu-plugin
 #
@@ -33,7 +33,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'time'
 
 class CheckDynamoDB < Sensu::Plugin::Check::CLI

--- a/plugins/aws/check-dynamodb-throttle.rb
+++ b/plugins/aws/check-dynamodb-throttle.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: time
 #   gem: sensu-plugin
 #
@@ -30,7 +30,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'time'
 
 class CheckDynamoDB < Sensu::Plugin::Check::CLI

--- a/plugins/aws/check-ec2-network.rb
+++ b/plugins/aws/check-ec2-network.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -30,7 +30,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckEc2Network < Sensu::Plugin::Check::CLI
   option :access_key_id,

--- a/plugins/aws/check-elb-certs.rb
+++ b/plugins/aws/check-elb-certs.rb
@@ -13,7 +13,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #   gem: openssl
 #   gem: net/http
@@ -33,7 +33,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'net/http'
 require 'openssl'
 

--- a/plugins/aws/check-elb-health-sdk.rb
+++ b/plugins/aws/check-elb-health-sdk.rb
@@ -14,7 +14,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: uri
 #   gem: net/http
 #   gem: sensu-plugin
@@ -28,7 +28,7 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'net/http'
 require 'uri'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class ELBHealth < Sensu::Plugin::Check::CLI
   option :aws_access_key,

--- a/plugins/aws/check-elb-latency.rb
+++ b/plugins/aws/check-elb-latency.rb
@@ -13,7 +13,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -33,7 +33,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckELBLatency < Sensu::Plugin::Check::CLI
   option :access_key_id,

--- a/plugins/aws/check-elb-nodes.rb
+++ b/plugins/aws/check-elb-nodes.rb
@@ -13,7 +13,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -33,7 +33,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckELBNodes < Sensu::Plugin::Check::CLI
   option :aws_access_key,

--- a/plugins/aws/check-elb-sum-requests.rb
+++ b/plugins/aws/check-elb-sum-requests.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -32,7 +32,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckELBSumRequests < Sensu::Plugin::Check::CLI
   option :access_key_id,

--- a/plugins/aws/check-instance-events.rb
+++ b/plugins/aws/check-instance-events.rb
@@ -13,7 +13,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -29,7 +29,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckInstanceEvents < Sensu::Plugin::Check::CLI
   option :aws_access_key,

--- a/plugins/aws/check-rds-events.rb
+++ b/plugins/aws/check-rds-events.rb
@@ -16,7 +16,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -31,7 +31,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckRDSEvents < Sensu::Plugin::Check::CLI
   option :aws_access_key,

--- a/plugins/aws/check-rds.rb
+++ b/plugins/aws/check-rds.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -45,7 +45,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 require 'time'
 
 class CheckRDS < Sensu::Plugin::Check::CLI

--- a/plugins/aws/check-redshift-events.rb
+++ b/plugins/aws/check-redshift-events.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -35,7 +35,7 @@
 #
 
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class CheckRedshiftEvents < Sensu::Plugin::Check::CLI
   option :aws_access_key,
@@ -63,7 +63,7 @@ class CheckRedshiftEvents < Sensu::Plugin::Check::CLI
          proc: proc { |a| a.split(',') },
          default: []
 
-  # setup a redshift connection using aws-sdk
+  # setup a redshift connection using aws-sdk-v1
   def redshift
     @redshift ||= AWS::Redshift::Client.new(
       access_key_id: config[:aws_access_key],

--- a/plugins/aws/check-ses-limit.rb
+++ b/plugins/aws/check-ses-limit.rb
@@ -14,7 +14,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:

--- a/plugins/aws/check-sqs-messages.rb
+++ b/plugins/aws/check-sqs-messages.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -29,7 +29,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class SQSMsgs < Sensu::Plugin::Check::CLI
   option :aws_access_key,

--- a/plugins/aws/ec2-count-metrics.rb
+++ b/plugins/aws/ec2-count-metrics.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -28,7 +28,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class EC2Metrics < Sensu::Plugin::Metric::CLI::Graphite
   option :scheme,

--- a/plugins/aws/elasticache-metrics.rb
+++ b/plugins/aws/elasticache-metrics.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # needs example command
@@ -33,7 +33,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class ElastiCacheMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :cacheclusterid,

--- a/plugins/aws/elb-full-metrics.rb
+++ b/plugins/aws/elb-full-metrics.rb
@@ -34,7 +34,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class ELBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :elbname,

--- a/plugins/aws/elb-metrics.rb
+++ b/plugins/aws/elb-metrics.rb
@@ -35,7 +35,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class ELBMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :elbname,

--- a/plugins/aws/sqs-metrics.rb
+++ b/plugins/aws/sqs-metrics.rb
@@ -12,7 +12,7 @@
 #   Linux
 #
 # DEPENDENCIES:
-#   gem: aws-sdk
+#   gem: aws-sdk-v1
 #   gem: sensu-plugin
 #
 # USAGE:
@@ -28,7 +28,7 @@
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/metric/cli'
-require 'aws-sdk'
+require 'aws-sdk-v1'
 
 class SQSMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :queue,


### PR DESCRIPTION
Due to the breaking release of v2 of the aws-sdk gem all of the current plugins need to be set to require aws-sdk-v1