### PR TITLE
Fix broken instance event check

### DIFF
--- a/plugins/aws/check-instance-events.rb
+++ b/plugins/aws/check-instance-events.rb
@@ -27,7 +27,6 @@
 #   for details.
 #
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'aws-sdk-v1'
 
@@ -95,7 +94,7 @@ class CheckInstanceEvents < Sensu::Plugin::Check::CLI
           #         "not_after": "2015-01-05 18:00:00 UTC"
           #     }
           # ]
-          unless i[:events_set].select { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }
+          if i[:events_set].select { |x| x[:code] == 'system-reboot' && x[:description] =~ /\[Completed\]/ }.empty?
             event_instances << i[:instance_id]
           end
         end


### PR DESCRIPTION
The logic in https://github.com/sensu/sensu-community-plugins/commit/04106ed83ef769470512e3a1dd2d56e1b772f957 was flawed and it causes this check to never return any instances with events.  Instances are being excluded if the select finds a reboot completed, but an empty array satisfies the unless so it never finds any instances even if they events.  I've tested this change in logic in my environment to show the nodes Amazon is about to reboot.  This should get merged ASAP since the event is upcoming for everyone.