### PR TITLE
updated slack.rb to use http proxy if defined

### DIFF
--- a/handlers/notification/slack.json
+++ b/handlers/notification/slack.json
@@ -6,7 +6,7 @@
     "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
     "bot_name": "optional bot name, defaults to slack defined",
     "proxy_addr": "optional - your proxy address for http proxy, like squid, i.e. 192.168.10.100",
-    "proxy_port": "optional - should be port used by proxy, i.e. 3128"
+    "proxy_port": "optional - should be port used by proxy, i.e. 3128",
     "markdown_enabled": false
   }
 }

--- a/handlers/notification/slack.json
+++ b/handlers/notification/slack.json
@@ -5,6 +5,8 @@
     "message_prefix": "optional prefix - can be used for mentions",
     "surround": "optional - can be used for bold(*), italics(_), code(`) and preformatted(```)",
     "bot_name": "optional bot name, defaults to slack defined",
+    "proxy_addr": "optional - your proxy address for http proxy, like squid, i.e. 192.168.10.100",
+    "proxy_port": "optional - should be port used by proxy, i.e. 3128"
     "markdown_enabled": false
   }
 }

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -30,6 +30,14 @@ class Slack < Sensu::Handler
     get_setting('channel')
   end
 
+  def slack_proxy_addr
+    get_setting('proxy_addr')
+  end
+
+  def slack_proxy_port
+    get_setting('proxy_port')
+  end
+
   def slack_message_prefix
     get_setting('message_prefix')
   end
@@ -69,7 +77,13 @@ class Slack < Sensu::Handler
 
   def post_data(notice)
     uri = URI(slack_webhook_url)
-    http = Net::HTTP.new(uri.host, uri.port)
+
+    if (defined?(slack_proxy_addr)).nil?
+      http = Net::HTTP.new(uri.host, uri.port)
+    else
+      http = Net::HTTP::Proxy(slack_proxy_addr, slack_proxy_port).new(uri.host, uri.port)
+    end
+
     http.use_ssl = true
 
     req = Net::HTTP::Post.new("#{uri.path}?#{uri.query}")


### PR DESCRIPTION
Using a http proxy like squid is common enough that it should be as easy to use as setting the proxy ip and port in your json config for the slack handler.

This does that.