### PR TITLE
Update system_profile.rb

### DIFF
--- a/extensions/checks/system_profile.rb
+++ b/extensions/checks/system_profile.rb
@@ -62,9 +62,11 @@ module Sensu
         @options = {
           interval: 10,
           handler: 'graphite',
+          add_metric_prefix: true,
+          metric_prefix: 'os',
           add_client_prefix: true,
           path_prefix: 'system',
-          prefix_at_start: 0
+          prefix_at_start: 1
         }
         if settings[:system_profile].is_a?(Hash)
           @options.merge!(settings[:system_profile])
@@ -84,6 +86,7 @@ module Sensu
         path << options[:path_prefix] if options[:prefix_at_start]
         path << settings[:client][:name] if options[:add_client_prefix]
         path << options[:path_prefix] unless options[:prefix_at_start]
+        path << options[:metric_prefix] if options[:add_metric_prefix]
         path = (path + args).join('.')
         @metrics << [path, value, Time.now.to_i].join(' ')
       end


### PR DESCRIPTION
For these metrics,I need two things added to the path:

1. A general prefix, before the client name. This is typically aws.region.vpc-number.subnet. I can achieve this with path_prefix, and with setting prefix_at_start: 1

2. A way to contain these metrics in their own branch under client name. Again, path_prefix could be used, with prefix_at_start: 0, but it's taken already.

So I've added metric_prefix, which now goes below client name but above these metrics. I think it's a lot more flexible this way, and makes for a more organized namespace.

Tested and works fine with Sensu 0.16.0 and Graphite 0.9.13-pre1