### PR TITLE
Bugfix - nginx-metrics.rb: Creates 10 GET requests because didn't check the status code

### DIFF
--- a/plugins/nginx/nginx-metrics.rb
+++ b/plugins/nginx/nginx-metrics.rb
@@ -86,6 +86,9 @@ class NginxMetrics < Sensu::Plugin::Metric::CLI::Graphite
           request = Net::HTTP::Get.new("/#{config[:path]}")
           connection.request(request)
         end
+        if response.code == '200'
+          found = true
+        end
       end
     end # until
 


### PR DESCRIPTION
10 GET req -> 1 GET req