### PR TITLE
Slack channels definable from Check config

### DIFF
--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -9,6 +9,22 @@
 # integration in slack. You can create the required webhook by visiting
 # https://{your team}.slack.com/services/new/incoming-webhook
 #
+# ## Client Configuraiton
+#
+# It is possible to select the Slack channel a message will be sent to at
+# event time using the 'sensu_channel' check configuration.
+#
+#    {
+#      "checks": {
+#      "my_check": {
+#        "handlers": ["default", "slack"],
+#        "slack_channel": "#mycustomchannel",
+#        "command": "some-command.sh",
+#        ...
+#      }
+#    }
+#
+#
 # After you configure your webhook, you'll need the webhook URL from the integration.
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
@@ -27,6 +43,9 @@ class Slack < Sensu::Handler
   end
 
   def slack_channel
+    if @event['check']['slack_channel']
+      return @event['check']['slack_channel']
+    end
     get_setting('channel')
   end
 
@@ -63,6 +82,7 @@ class Slack < Sensu::Handler
   end
 
   def handle
+
     description = @event['check']['notification'] || build_description
     post_data("*Check*\n#{incident_key}\n\n*Description*\n#{description}")
   end

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
-
 # Copyright 2014 Dan Shultz and contributors.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE

--- a/handlers/notification/slack.rb
+++ b/handlers/notification/slack.rb
@@ -81,7 +81,6 @@ class Slack < Sensu::Handler
   end
 
   def handle
-
     description = @event['check']['notification'] || build_description
     post_data("*Check*\n#{incident_key}\n\n*Description*\n#{description}")
   end


### PR DESCRIPTION
Enable checks to specify a target Slack room (or use) from their check configuration.
## Client Configuraiton

 It is possible to select the Slack channel a message will be sent to at event time using the 'sensu_channel' check configuration.

The channel can be defined as either a `#channel` or a `@user` - multiple values are not yet supported.

```
{
  "checks": {
  "my_check": {
    "handlers": ["default", "slack"],
    "slack_channel": "#mycustomchannel",
    "command": "some-command.sh",
    ...
  }
}
```
