### PR TITLE
snmp metrics improvements/fixes

### DIFF
--- a/plugins/snmp/snmp-bulk-metrics.rb
+++ b/plugins/snmp/snmp-bulk-metrics.rb
@@ -103,10 +103,14 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
     response.each_varbind do |vb|
       name = vb.oid
       name = "#{name}".gsub('.', '_') if config[:graphite]
-      if config[:prefix]
-        output "#{config[:prefix]}.#{config[:host]}.#{config[:suffix]}.#{name}", vb.value.to_f
-      else
-        output "#{config[:host]}.#{config[:suffix]}.#{name}", vb.value.to_f
+      begin
+        if config[:prefix]
+          output "#{config[:prefix]}.#{config[:host]}.#{config[:suffix]}.#{name}", value.to_f
+        else
+          output "#{config[:host]}.#{config[:suffix]}.#{name}", vb.value.to_f
+        end
+      rescue NameError
+        # Some values may fail to cast to float
       end
     end
     manager.close

--- a/plugins/snmp/snmp-bulk-metrics.rb
+++ b/plugins/snmp/snmp-bulk-metrics.rb
@@ -67,17 +67,30 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Number of supplied OIDs that should not be iterated over (defaults to 0)',
          default: 0
 
+  option :mibdir,
+         short: '-d mibdir',
+         description: 'Full path to custom MIB directory.'
+
+  option :mibs,
+         short: '-l mib[,mib,mib...]',
+         description: 'Custom MIBs to load (from custom mib path).',
+         default: ''
+
   option :timeout,
          short: '-t timeout (seconds) (defaults to 5)',
          default: 5
 
   def run
     oids = config[:objectid].split(',')
+    mibs = config[:mibs].split(',')
     begin
       manager = SNMP::Manager.new(host: "#{config[:host]}",
                                   community: "#{config[:community]}",
                                   version: config[:snmp_version].to_sym,
                                   timeout: config[:timeout].to_i)
+      if config[:mibdir] and not mibs.empty?
+        manager.load_modules(mibs, config[:mibdir])
+      end
       response = manager.get_bulk(config[:nonrepeat].to_i,
                                   config[:maxrepeat].to_i,
                                   oids)

--- a/plugins/snmp/snmp-metrics.rb
+++ b/plugins/snmp/snmp-metrics.rb
@@ -57,9 +57,23 @@ class SNMPGraphite < Sensu::Plugin::Metric::CLI::Graphite
          description: 'Replace dots with underscores in hostname',
          boolean: true
 
+  option :mibdir,
+         short: '-d mibdir',
+         description: 'Full path to custom MIB directory.'
+
+  option :mibs,
+         short: '-l mib[,mib,mib...]',
+         description: 'Custom MIBs to load (from custom mib path).',
+         default: ''
+
+
   def run
+    mibs = config[:mibs].split(',')
     begin
       manager = SNMP::Manager.new(host: "#{config[:host]}", community: "#{config[:community]}", version: config[:snmp_version].to_sym)
+      if config[:mibdir] and not mibs.empty?
+        manager.load_modules(mibs, config[:mibdir])
+      end
       response = manager.get(["#{config[:objectid]}"])
     rescue SNMP::RequestTimeout
       unknown "#{config[:host]} not responding"


### PR DESCRIPTION
Add custom MIB loading capabilities to provide better metric names in output.
Rescue cases where a failure to float a value may occur.