### PR TITLE
Use unknown instead of message

### DIFF
--- a/plugins/http/check-https-cert.rb
+++ b/plugins/http/check-https-cert.rb
@@ -72,7 +72,6 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
     end
 
   rescue
-    message "Could not connect to #{config[:url]}"
-    exit 1
+    unknown "Could not connect to #{config[:url]}"
   end
 end


### PR DESCRIPTION
Not sure if message is a relic of the past or something, but as I was testing this check, I wasn't getting any output, so I made it call unknown anyway and now it works great.