### PR TITLE
ES graphite node - return more metrics

### DIFF
--- a/plugins/elasticsearch/es-node-graphite.rb
+++ b/plugins/elasticsearch/es-node-graphite.rb
@@ -193,7 +193,7 @@ class ESMetrics < Sensu::Plugin::Metric::CLI::Graphite
     node['indices'].each do |type,  index|
       index.each do |k, v|
         # #YELLOW
-        unless k =~ /(_time|memory|size$)/ # rubocop:disable IfUnlessModifier
+        unless k =~ /(_time$)/ || v =~ /\d+/ # rubocop:disable IfUnlessModifier
           metrics["indices.#{type}.#{k}"] = v
         end
       end


### PR DESCRIPTION
Hello,

we need to track more metrics from ES servers(size of fielddata and filter_cache) and these were limited by  ```/(_time|memory|size$)/``` regular expression. New approach is to test the value and add when it's numerical. Previous ```/_time/``` is kept for some backward compatibility with older version of ES (and maybe it's not needed).