### PR TITLE
Added encoding option, and Set default encoding to ASCII-8BIT

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+# encoding: UTF-8
 #
 # Check Procs
 # ===

--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -146,6 +146,11 @@ class CheckProcs < Sensu::Plugin::Check::CLI
          proc: proc(&:to_i),
          description: 'Match processes cpu time that is younger than this, in SECONDS'
 
+  option :encoding,
+         :description => "Explicit encoding when reading process list",
+         :long => '--encoding ENCODING',
+         :default => "ASCII-8BIT"
+
   def read_pid(path)
     if File.exist?(path)
       File.read(path).strip.to_i
@@ -155,7 +160,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
   end
 
   def read_lines(cmd)
-    IO.popen(cmd + ' 2>&1') do |child|
+    IO.popen(cmd + ' 2>&1', :external_encoding=>config[:encoding]) do |child|
       child.read.split("\n")
     end
   end

--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -147,9 +147,9 @@ class CheckProcs < Sensu::Plugin::Check::CLI
          description: 'Match processes cpu time that is younger than this, in SECONDS'
 
   option :encoding,
-         :description => "Explicit encoding when reading process list",
-         :long => '--encoding ENCODING',
-         :default => "ASCII-8BIT"
+         description: 'Explicit encoding when reading process list',
+         long: '--encoding ENCODING',
+         default: 'ASCII-8BIT''
 
   def read_pid(path)
     if File.exist?(path)
@@ -160,7 +160,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
   end
 
   def read_lines(cmd)
-    IO.popen(cmd + ' 2>&1', :external_encoding=>config[:encoding]) do |child|
+    IO.popen(cmd + ' 2>&1', {external_encoding:config[:encoding]}) do |child|
       child.read.split("\n")
     end
   end

--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -160,7 +160,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
   end
 
   def read_lines(cmd)
-    IO.popen(cmd + ' 2>&1', {external_encoding:config[:encoding]}) do |child|
+    IO.popen(cmd + ' 2>&1', external_encoding: config[:encoding]) do |child|
       child.read.split("\n")
     end
   end

--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -149,7 +149,7 @@ class CheckProcs < Sensu::Plugin::Check::CLI
   option :encoding,
          description: 'Explicit encoding when reading process list',
          long: '--encoding ENCODING',
-         default: 'ASCII-8BIT''
+         default: 'ASCII-8BIT'
 
   def read_pid(path)
     if File.exist?(path)


### PR DESCRIPTION
Fixed https://github.com/sensu/sensu-community-plugins/issues/802.

Default is set to ASCII-8BIT instead of US-ASCII to handle all characters even if it is not the right encoding (unicode). It allows check-procs.rb to not generate exception even if encoding is unicode.