### PR TITLE
Added username/password support for nodetool - cassandra-graphite.rb - Cassandra monitoring

### DIFF
--- a/plugins/cassandra/cassandra-graphite.rb
+++ b/plugins/cassandra/cassandra-graphite.rb
@@ -93,6 +93,16 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
          description: 'cassandra JMX port',
          default: '7199'
 
+  option :username,
+         short: '-u USERNAME',
+         long: '--username USERNAME',
+         description: 'cassandra JMX username'
+
+  option :password,
+         short: '-p PASSWORD',
+         long: '--password PASSWORD',
+         description: 'cassandra JMX password'
+
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
          short: '-s SCHEME',
@@ -145,7 +155,11 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   # execute cassandra's nodetool and return output as string
   def nodetool_cmd(cmd)
-    `nodetool -h #{config[:hostname]} -p #{config[:port]} #{cmd}`
+    if config[:username] && config[:password]
+      `nodetool -h #{config[:hostname]} -u #{config[:username]} -pw #{config[:password]} -p #{config[:port]} #{cmd}`
+    else
+      `nodetool -h #{config[:hostname]} -p #{config[:port]} #{cmd}`
+    end
   end
 
   # nodetool -h localhost info:

--- a/plugins/cassandra/cassandra-graphite.rb
+++ b/plugins/cassandra/cassandra-graphite.rb
@@ -103,6 +103,11 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
          long: '--password PASSWORD',
          description: 'cassandra JMX password'
 
+  option :passwordfile,
+         short: '-F PASSWORD-FILE',
+         long: '--password-file PASSWORD-FILE',
+         description: 'cassandra JMX password file'
+
   option :scheme,
          description: 'Metric naming scheme, text to prepend to metric',
          short: '-s SCHEME',
@@ -155,8 +160,12 @@ class CassandraMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
   # execute cassandra's nodetool and return output as string
   def nodetool_cmd(cmd)
-    if config[:username] && config[:password]
-      `nodetool -h #{config[:hostname]} -u #{config[:username]} -pw #{config[:password]} -p #{config[:port]} #{cmd}`
+    if config[:username]
+      if config[:passwordfile]
+        `nodetool -h #{config[:hostname]} -u #{config[:username]} -pwf #{config[:passwordfile]} -p #{config[:port]} #{cmd}`
+      elsif config[:password]
+        `nodetool -h #{config[:hostname]} -u #{config[:username]} -pw #{config[:password]} -p #{config[:port]} #{cmd}`
+      end
     else
       `nodetool -h #{config[:hostname]} -p #{config[:port]} #{cmd}`
     end


### PR DESCRIPTION
We can now run cassandra-graphite.rb with -u/-p options for those using
authentication on the JMX.This is best practice considering the new recent
vulnerability affecting Cassandra:

CVE-2015-0225 ( http://www.securityfocus.com/archive/1/535154 )