### PR TITLE
Added component support to StatusPage.io handler

### DIFF
--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -50,19 +50,19 @@ class StatusPage < Sensu::Handler
     description = @event['notification'] || [@event['client']['name'], @event['check']['name'], @event['check']['output']].join(' : ')
     begin
       timeout(3) do
-        if @event['check'].has_key?('component_id')
-            status = case @event['action']
-                when 'create'
-                    'major_outage'
-                when 'resolve'
-                    'operational'
-                else
-                    nil
+        if @event['check'].key?.('component_id')
+          status = case @event['action']
+            when 'create'
+              'major_outage'
+            when 'resolve'
+              'operational'
+            else
+              nil
             end
             unless status.nil?
-                statuspage.update_component(
-                    :component_id => @event['check']['component_id'],
-                    :status => status)
+              statuspage.update_component(
+                :component_id => @event['check']['component_id'],
+                :status => status)
             end
         end
         response = case @event['action']

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -59,11 +59,11 @@ class StatusPage < Sensu::Handler
                    else
                      nil
                    end
-            unless status.nil?
-              statuspage.update_component(
-                component_id: @event['check']['component_id'],
-                status: status)
-            end
+          unless status.nil?
+            statuspage.update_component(
+              component_id: @event['check']['component_id'],
+              status: status)
+          end
         end
         response = case @event['action']
                    when 'create'

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -15,7 +15,8 @@
 # gem build redphone.gemspec OR /opt/sensu/embedded/bin/gem build redphone.gemspec
 # gem install redphone-0.0.6.gem OR /opt/sensu/embedded/bin/gem install redphone-0.0.6.gem
 #
-# To update a component add a "component_id": "IDHERE" attribute to the corresponding check defination
+# To update a component add a "component_id": "IDHERE" attribute to the corresponding check definition
+
 # Example:
 # {
 #    "checks": {
@@ -28,6 +29,7 @@
 #      }
 #    }
 # }
+
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -1,19 +1,33 @@
 #!/usr/bin/env ruby
 #
-# This handler creates and updates incidents for StatusPage.IO.
+# This handler creates and updates incidents and changes a component status (optional) for StatusPage.IO.
 # Due to a bug with their API, please pair a Twitter account to your StatusPage even if you don't plan to tweet.
+# Components only support 'major_outage' and 'operational' at this time 
 #
 # Copyright 2011 Sonian, Inc <chefs@sonian.net>
 # Copyright 2013 DISQUS, Inc.
-# Updated by jfledvin with Redphone Instructions & Component Support 4/5/2015
+# Updated by jfledvin with Redphone Instructions & Basic Component Support 4/5/2015
 #
-# NOTE: As of this writing redphone has not added StatusPage.io support
-# You must manually create th gem by:
+# NOTE: As of this writing Redphone has not added StatusPage.io support to v0.0.6
+# You must manually build and install the gem:
 # git clone https://github.com/portertech/redphone.git
 # cd redphone
 # gem build redphone.gemspec OR /opt/sensu/embedded/bin/gem build redphone.gemspec
 # gem install redphone-0.0.6.gem OR /opt/sensu/embedded/bin/gem install redphone-0.0.6.gem
 #
+# To update a component add a "component_id": "IDHERE" attribute to the corresponding check defination
+# Example:
+#{
+#  "checks": {
+#    "check_sshd": {
+#      "handlers": ["statuspage"],
+#      "component_id": "IDHERE",
+#      "command": "/etc/sensu/plugins/check-procs.rb -p sshd -C 1 ",
+#      "interval": 60,
+#      "subscribers": [ "default" ]
+#    }
+#  }
+#}
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -61,8 +61,8 @@ class StatusPage < Sensu::Handler
             end
             unless status.nil?
               statuspage.update_component(
-                :component_id => @event['check']['component_id'],
-                :status => status)
+                component_id: @event['check']['component_id'],
+                status: status)
             end
         end
         response = case @event['action']

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -52,13 +52,13 @@ class StatusPage < Sensu::Handler
       timeout(3) do
         if @event['check'].key?('component_id')
           status = case @event['action']
-            when 'create'
-              'major_outage'
-            when 'resolve'
-              'operational'
-            else
-              nil
-            end
+                   when 'create'
+                     'major_outage'
+                   when 'resolve'
+                     'operational'
+                   else
+                     nil
+                   end
             unless status.nil?
               statuspage.update_component(
                 component_id: @event['check']['component_id'],

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -50,7 +50,7 @@ class StatusPage < Sensu::Handler
     description = @event['notification'] || [@event['client']['name'], @event['check']['name'], @event['check']['output']].join(' : ')
     begin
       timeout(3) do
-        if @event['check'].key?.('component_id')
+        if @event['check'].key?('component_id')
           status = case @event['action']
             when 'create'
               'major_outage'

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -2,7 +2,7 @@
 #
 # This handler creates and updates incidents and changes a component status (optional) for StatusPage.IO.
 # Due to a bug with their API, please pair a Twitter account to your StatusPage even if you don't plan to tweet.
-# Components only support 'major_outage' and 'operational' at this time 
+# Components only support 'major_outage' and 'operational' at this time
 #
 # Copyright 2011 Sonian, Inc <chefs@sonian.net>
 # Copyright 2013 DISQUS, Inc.
@@ -17,17 +17,17 @@
 #
 # To update a component add a "component_id": "IDHERE" attribute to the corresponding check defination
 # Example:
-#{
-#  "checks": {
-#    "check_sshd": {
-#      "handlers": ["statuspage"],
-#      "component_id": "IDHERE",
-#      "command": "/etc/sensu/plugins/check-procs.rb -p sshd -C 1 ",
-#      "interval": 60,
-#      "subscribers": [ "default" ]
+# {
+#    "checks": {
+#      "check_sshd": {
+#        "handlers": ["statuspage"],
+#        "component_id": "IDHERE",
+#        "command": "/etc/sensu/plugins/check-procs.rb -p sshd -C 1 ",
+#        "interval": 60,
+#        "subscribers": [ "default" ]
+#      }
 #    }
-#  }
-#}
+# }
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -5,6 +5,14 @@
 #
 # Copyright 2011 Sonian, Inc <chefs@sonian.net>
 # Copyright 2013 DISQUS, Inc.
+# Updated by jfledvin with Redphone Instructions 4/5/2015
+#
+# NOTE: As of this writing redphone has not added StatusPage.io support
+# You must manually create th gem by:
+# git clone https://github.com/portertech/redphone.git
+# cd redphone
+# gem build redphone.gemspec OR /opt/sensu/embedded/bin/gem build redphone.gemspec
+# gem install redphone-0.0.6.gem OR /opt/sensu/embedded/bin/gem install redphone-0.0.6.gem
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
@@ -26,6 +34,21 @@ class StatusPage < Sensu::Handler
     description = @event['notification'] || [@event['client']['name'], @event['check']['name'], @event['check']['output']].join(' : ')
     begin
       timeout(3) do
+        if @event['check'].has_key?('component_id')
+            status = case @event['action']
+                when 'create'
+                    'major_outage'
+                when 'resolve'
+                    'operational'
+                else
+                    nil
+            end
+            unless status.nil?
+                statuspage.update_component(
+                    :component_id => @event['check']['component_id'],
+                    :status => status)
+            end
+        end
         response = case @event['action']
                    when 'create'
                      # #YELLOW

--- a/handlers/notification/statuspage.rb
+++ b/handlers/notification/statuspage.rb
@@ -5,7 +5,7 @@
 #
 # Copyright 2011 Sonian, Inc <chefs@sonian.net>
 # Copyright 2013 DISQUS, Inc.
-# Updated by jfledvin with Redphone Instructions 4/5/2015
+# Updated by jfledvin with Redphone Instructions & Component Support 4/5/2015
 #
 # NOTE: As of this writing redphone has not added StatusPage.io support
 # You must manually create th gem by:


### PR DESCRIPTION
I added support for updating a component if defined for the StatusPage.io handler. Tested this out in our environment and it works well. If there are necessary changes to get this merged let me know, Ruby is not my native language. 

(gem install redphone does not provide a gem with StatusPage.io support so I've also added instructions on how to get that working)