### PR TITLE
more checks to rabbitmq-node-health.rb

### DIFF
--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -18,7 +18,7 @@
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
-require 'rest_client'
+require 'rest-client'
 
 class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
   option :host,
@@ -59,6 +59,34 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
          proc: proc(&:to_f),
          default: 90
 
+  option :fdwarn,
+         description: 'Warning % of file descriptor usage vs high watermark',
+         short: '-m',
+         long: '--mwarn PERCENT',
+         proc: proc(&:to_f),
+         default: 80
+
+  option :fdcrit,
+         description: 'Critical % of file descriptor usage vs high watermark',
+         short: '-c',
+         long: '--mcrit PERCENT',
+         proc: proc(&:to_f),
+         default: 90
+
+  option :socketwarn,
+         description: 'Warning % of socket usage vs high watermark',
+         short: '-m',
+         long: '--mwarn PERCENT',
+         proc: proc(&:to_f),
+         default: 80
+
+  option :socketcrit,
+         description: 'Critical % of socket usage vs high watermark',
+         short: '-c',
+         long: '--mcrit PERCENT',
+         proc: proc(&:to_f),
+         default: 90
+
   option :watchalarms,
          description: 'Sound critical if one or more alarms are triggered',
          short: '-a BOOLEAN',
@@ -92,17 +120,37 @@ class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
 
       # Determine % memory consumed
       pmem = sprintf('%.2f', nodeinfo['mem_used'].fdiv(nodeinfo['mem_limit']) * 100)
+      # Determine % sockets consumed
+      psocket = sprintf('%.2f', nodeinfo['sockets_used'].fdiv(nodeinfo['sockets_total']) * 100)
+      # Determine % file descriptors consumed
+      pfd = sprintf('%.2f', nodeinfo['fd_used'].fdiv(nodeinfo['fd_total']) * 100)
 
       # build status and message
       status = 'ok'
       message = 'Server is healthy'
+
+      # criticals
       if pmem.to_f >= config[:memcrit]
         message = "Memory usage is critical: #{pmem}%"
         status = 'critical'
+      elsif psocket.to_f >= config[:socketcrit]
+        message = "Socket usage is critical: #{psocket}%"
+        status = 'critical'
+      elsif pfd.to_f >= config[:fdcrit]
+        message = "Socket usage is critical: #{pfd}%"
+        status = 'critical'
+      # warnings
       elsif pmem.to_f >= config[:memwarn]
         message = "Memory usage is at warning: #{pmem}%"
         status = 'warning'
+      elsif psocket.to_f >= config[:socketwarn]
+        message = "Socket usage is at warning: #{psocket}%"
+        status = 'warning'
+      elsif pfd.to_f >= config[:fdwarn]
+        message = "Socket usage is at warning: #{pfd}%"
+        status = 'warning'
       end
+
       # If we are set to watch alarms then watch those and set status and messages accordingly
       if config[:watchalarms] == 'true'
         if nodeinfo['mem_alarm'] == true


### PR DESCRIPTION
In our rabbit nodes, we sometimes have issues with running out of sockets or file descriptors. Updating file to accommodate those checks. I also noticed a warning about rest_client being deprecated, so I swapped it to rest-client.

Apologies for any sloppiness. Ruby is not my forte'.