### PR TITLE
Fix check-disk-health for OK status

### DIFF
--- a/plugins/system/check-disk-health.sh
+++ b/plugins/system/check-disk-health.sh
@@ -18,7 +18,7 @@ FAILS=()
 # loop devices
 for DEVICE in $DEVICES; do
 	# get device status
-	STATUS=$( smartctl -H /dev/$DEVICE | grep PASSED > /dev/null && echo "OK" )
+	STATUS=$( smartctl -H /dev/$DEVICE | grep 'OK\|PASSED' > /dev/null && echo "OK" )
 
 	# push to fails
 	if ! [ "$STATUS" == "OK" ]; then


### PR DESCRIPTION
Some firmware reports

    === START OF READ SMART DATA SECTION ===
    SMART Health Status: OK

on `smartctl -H`.

http://sourceforge.net/p/smartmontools/mailman/message/32936537/