### PR TITLE
Sync changes from sensu-plugins-rabbitmq repo

### DIFF
--- a/plugins/rabbitmq/check-rabbitmq-consumers.rb
+++ b/plugins/rabbitmq/check-rabbitmq-consumers.rb
@@ -18,7 +18,7 @@
 # LICENSE:
 # Copyright 2014 Daniel Kerwin <d.kerwin@gini.net>
 # Copyright 2014 Tim Smith <tim@cozy.co>
-# 
+#
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 

--- a/plugins/rabbitmq/check-rabbitmq-consumers.rb
+++ b/plugins/rabbitmq/check-rabbitmq-consumers.rb
@@ -1,17 +1,31 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # Check RabbitMQ consumers
-# ========================
+# ===
 #
+# DESCRIPTION:
+# This plugin checks the number of consumers on the RabbitMQ server
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2014 Daniel Kerwin <d.kerwin@gini.net>
 # Copyright 2014 Tim Smith <tim@cozy.co>
-#
+# 
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
 require 'sensu-plugin/check/cli'
 require 'carrot-top'
 
+# main plugin class
 class CheckRabbitMQConsumers < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ management API host',

--- a/plugins/rabbitmq/check-rabbitmq-messages.rb
+++ b/plugins/rabbitmq/check-rabbitmq-messages.rb
@@ -1,8 +1,21 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
-# Check RabbitMQ messages
+# Check RabbitMQ Messages
 # ===
 #
+# DESCRIPTION:
+# This plugin checks the total number of messages queued on the RabbitMQ server
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2012 Evan Hazlett <ejhazlett@gmail.com>
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
@@ -12,6 +25,7 @@ require 'sensu-plugin/check/cli'
 require 'socket'
 require 'carrot-top'
 
+# main plugin class
 class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ management API host',

--- a/plugins/rabbitmq/check-rabbitmq-queue-drain-time.rb
+++ b/plugins/rabbitmq/check-rabbitmq-queue-drain-time.rb
@@ -1,7 +1,10 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ Queue Drain Time
 # ===
+#
+# DESCRIPTION:
 # This plugin checks the time it will take for each queue on the RabbitMQ
 # server to drain based on the current message egress rate.  For example
 # if a queue has 1,000 messages in it, but egresses only 1 message a sec
@@ -9,6 +12,15 @@
 #
 # The plugin is based on the RabbitMQ Queue Metrics plugin
 #
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2015 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
@@ -18,6 +30,7 @@ require 'sensu-plugin/check/cli'
 require 'socket'
 require 'carrot-top'
 
+# main plugin class
 class CheckRabbitMQQueueDrainTime < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ management API host',

--- a/plugins/rabbitmq/check-rabbitmq-queue.rb
+++ b/plugins/rabbitmq/check-rabbitmq-queue.rb
@@ -1,18 +1,31 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
-# Check RabbitMQ messages
+# Check RabbitMQ Queue Messages
 # ===
 #
+# DESCRIPTION:
+# This plugin checks the number of messages queued on the RabbitMQ server in a specific queues
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2012 Evan Hazlett <ejhazlett@gmail.com>
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'socket'
 require 'carrot-top'
 
+# main plugin class
 class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ management API host',
@@ -85,15 +98,12 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
         next
       end
       queues.each do |queue|
-        if queue['name'] == q
-          total = queue['messages']
-          if total.nil?
-            total = 0
-          end
-          message "#{total}"
-          @crit <<  "#{ q }:#{ total }" if total > config[:critical].to_i
-          @warn << "#{ q }:#{ total }" if total > config[:warn].to_i
-        end
+        skip unless queue['name'] == q
+        total = queue['messages']
+        total = 0 if total.nil?
+        message "#{total}"
+        @crit << "#{ q }:#{ total }" if total > config[:critical].to_i
+        @warn << "#{ q }:#{ total }" if total > config[:warn].to_i
       end
     end
     if @crit.empty? && @warn.empty?

--- a/plugins/rabbitmq/rabbitmq-alive.rb
+++ b/plugins/rabbitmq/rabbitmq-alive.rb
@@ -1,10 +1,21 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ check alive plugin
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if RabbitMQ server is alive using the REST API
 #
+# PLATFORMS:
+#   Linux, Windows, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# LICENSE:
 # Copyright 2012 Abhijith G <abhi@runa.com> and Runa Inc.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
@@ -14,7 +25,8 @@ require 'sensu-plugin/check/cli'
 require 'json'
 require 'rest_client'
 
-class CheckRabbitMQ < Sensu::Plugin::Check::CLI
+# main plugin class
+class CheckRabbitMQAlive < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ host',
          short: '-w',

--- a/plugins/rabbitmq/rabbitmq-amqp-alive.rb
+++ b/plugins/rabbitmq/rabbitmq-amqp-alive.rb
@@ -1,10 +1,21 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
-# RabbitMQ check alive plugin
+# RabbitMQ check amqp alive plugin
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if RabbitMQ server is alive using the REST API
 #
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: bunny
+#
+# LICENSE:
 # Copyright 2013 Milos Gajdos
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
@@ -13,7 +24,8 @@
 require 'sensu-plugin/check/cli'
 require 'bunny'
 
-class CheckRabbitAMQP < Sensu::Plugin::Check::CLI
+# main plugin class
+class CheckRabbitAMQPAlive < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ host',
          short: '-w',

--- a/plugins/rabbitmq/rabbitmq-cluster-health.rb
+++ b/plugins/rabbitmq/rabbitmq-cluster-health.rb
@@ -1,16 +1,24 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ check cluster nodes health plugin
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if RabbitMQ server's cluster nodes are in a running state.
 # It also accepts and optional list of nodes and verifies that those nodes are
 # present in the cluster.
 # The plugin is based on the RabbitMQ alive plugin by Abhijith G.
 #
-#  Todo:
-#    - Add ability to specify http vs. https
+# PLATFORMS:
+#   Linux, Windows, BSD, Solaris
 #
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# LICENSE:
 # Copyright 2012 Abhijith G <abhi@runa.com> and Runa Inc.
 # Copyright 2014 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
 #
@@ -21,6 +29,7 @@ require 'sensu-plugin/check/cli'
 require 'json'
 require 'rest_client'
 
+# main plugin class
 class CheckRabbitMQCluster < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ host',

--- a/plugins/rabbitmq/rabbitmq-network-partitions.rb
+++ b/plugins/rabbitmq/rabbitmq-network-partitions.rb
@@ -1,24 +1,31 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ Network Partitions Check
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if a RabbitMQ network partition has occured.
 # https://www.rabbitmq.com/partitions.html
 #
-# DEPENDENCIES:
-# gem: sensu-plugin
-# gem: carrot-top
+# PLATFORMS:
+#   Linux, BSD, Solaris
 #
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2015 Ed Robinson <ed@reevoo.com> and Reevoo LTD.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'carrot-top'
 
+# main plugin class
 class CheckRabbitMQPartitions < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ management API host',
@@ -33,13 +40,13 @@ class CheckRabbitMQPartitions < Sensu::Plugin::Check::CLI
          default: 15_672
 
   option :username,
-         description: 'RabbitMQ username',
+         description: 'RabbitMQ management API user',
          short: '-u',
          long: '--username USERNAME',
          default: 'guest'
 
   option :password,
-         description: 'RabbitMQ password',
+         description: 'RabbitMQ management API password',
          short: '-p',
          long: '--password PASSWORD',
          default: 'guest'

--- a/plugins/rabbitmq/rabbitmq-node-health.rb
+++ b/plugins/rabbitmq/rabbitmq-node-health.rb
@@ -1,13 +1,23 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ check node health plugin
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if RabbitMQ server node is in a running state.
 #
 # The plugin is based on the RabbitMQ cluster node health plugin by Tim Smith
 #
+# PLATFORMS:
+#   Linux, Windows, BSD, Solaris
 #
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: rest-client
+#
+# LICENSE:
 # Copyright 2012 Abhijith G <abhi@runa.com> and Runa Inc.
 # Copyright 2014 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
 # Copyright 2015 Edward McLain <ed@edmclain.com> and Daxko, LLC.
@@ -15,12 +25,12 @@
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
 
-require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 require 'json'
-require 'rest-client'
+require 'rest_client'
 
-class CheckRabbitMQNode < Sensu::Plugin::Check::CLI
+# main plugin class
+class CheckRabbitMQNodeHealth < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ host',
          short: '-w',

--- a/plugins/rabbitmq/rabbitmq-overview-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-overview-metrics.rb
@@ -1,16 +1,10 @@
 #!/usr/bin/env ruby
-
+#  encoding: UTF-8
 #
 # RabbitMQ Overview Metrics
 # ===
 #
-# Dependencies
-# -----------
-# - RabbitMQ `rabbitmq_management` plugin
-# - Ruby gem `carrot-top`
-#
-# Overview stats
-# ---------------
+# DESCRIPTION:
 # RabbitMQ 'overview' stats are similar to what is shown on the main page
 # of the rabbitmq_management web UI. Example:
 #
@@ -28,6 +22,15 @@
 #    host.rabbitmq.message_stats.deliver_get.count 6661111 1344186404
 #    host.rabbitmq.message_stats.deliver_get.rate  24.6867565643405  1344186404#
 #
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2012 Joe Miller - https://github.com/joemiller
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
@@ -37,6 +40,7 @@ require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'carrot-top'
 
+# main plugin class
 class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :host,
          description: 'RabbitMQ management API host',

--- a/plugins/rabbitmq/rabbitmq-queue-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-queue-metrics.rb
@@ -1,8 +1,25 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ Queue Metrics
 # ===
 #
+# DESCRIPTION:
+# This plugin checks gathers the following per queue rabbitmq metrics:
+#   - message count
+#   - average egress rate
+#   - "drain time" metric, which is the time a queue will take to reach 0 based on the egress rate
+#   - consumer count
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: carrot-top
+#
+# LICENSE:
 # Copyright 2011 Sonian, Inc <chefs@sonian.net>
 # Copyright 2015 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
 #
@@ -13,6 +30,7 @@ require 'sensu-plugin/metric/cli'
 require 'socket'
 require 'carrot-top'
 
+# main plugin class
 class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :host,
          description: 'RabbitMQ management API host',
@@ -77,9 +95,12 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       drain_time = 0 if drain_time.nan? # 0 rate with 0 messages is 0 time to drain
       output([config[:scheme], queue['name'], 'drain_time'].join('.'), drain_time.to_i, timestamp)
 
-      %w(messages).each do |metric|
+      %w(messages consumers).each do |metric|
         output([config[:scheme], queue['name'], metric].join('.'), queue[metric], timestamp)
       end
+
+      # fetch the average egress rate of the queue
+      output([config[:scheme], queue['name'], 'avg_egress_rate'].join('.'), queue['backing_queue_status']['avg_egress_rate'], timestamp)
     end
     ok
   end

--- a/plugins/rabbitmq/rabbitmq-stomp-alive.rb
+++ b/plugins/rabbitmq/rabbitmq-stomp-alive.rb
@@ -1,13 +1,25 @@
 #!/usr/bin/env ruby
+#  encoding: UTF-8
 #
 # RabbitMQ check alive plugin
 # ===
 #
+# DESCRIPTION:
 # This plugin checks if RabbitMQ server is alive and responding to STOMP
 # requests.
 #
-# Copyright 2014 Adam Ashley
 # Based on rabbitmq-amqp-alive by Milos Gajdos
+#
+# PLATFORMS:
+#   Linux, BSD, Solaris
+#
+# DEPENDENCIES:
+#   RabbitMQ rabbitmq_management plugin
+#   gem: sensu-plugin
+#   gem: stomp
+#
+# LICENSE:
+# Copyright 2014 Adam Ashley
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
@@ -15,6 +27,7 @@
 require 'sensu-plugin/check/cli'
 require 'stomp'
 
+# main plugin class
 class CheckRabbitStomp < Sensu::Plugin::Check::CLI
   option :host,
          description: 'RabbitMQ host',


### PR DESCRIPTION
Standardize headers.  Add dependency / platform information
Resolve rubocop warnings
Remove Ruby 1.8.7 backwards compat

Also brings in additional metrics for the queue monitor (egress rate and consumer count)