### PR TITLE
Additional pattern option for check dir count

### DIFF
--- a/plugins/files/check_dir_count.rb
+++ b/plugins/files/check_dir_count.rb
@@ -37,7 +37,7 @@ class DirCount < Sensu::Plugin::Check::CLI
          required: true
 
   option :file_pattern,
-         description: 'file file_pattern to search for',
+         description: 'file pattern to search for',
          short: '-p PAT',
          long: '--pattern PAT',
          default: '*'

--- a/plugins/files/check_dir_count.rb
+++ b/plugins/files/check_dir_count.rb
@@ -36,6 +36,12 @@ class DirCount < Sensu::Plugin::Check::CLI
          long: '--dir DIR',
          required: true
 
+  option :file_pattern,
+         description: 'file file_pattern to search for',
+         short: '-p PAT',
+         long: '--pattern PAT',
+         default: '*'
+
   option :warning_num,
          description: 'Warn if count of files is greater than provided number',
          short: '-w NUM',
@@ -49,14 +55,15 @@ class DirCount < Sensu::Plugin::Check::CLI
          required: true
 
   def run
-    begin
-      # Subtract two for '.' and '..'
-      num_files = Dir.entries(config[:directory]).count - 2
-    rescue
-      unknown "Error listing files in #{config[:directory]}"
+    if File.directory?(config[:directory])
+      num_files = Dir.glob(File.join(config[:directory], config[:file_pattern])).count
+    else
+      num_files = nil
     end
 
-    if num_files >= config[:critical_num].to_i
+    if num_files.nil?
+      unknown "Error listing files in #{config[:directory]}"
+    elsif num_files >= config[:critical_num].to_i
       critical "#{config[:directory]} has #{num_files} files (threshold: #{config[:critical_num]})"
     elsif num_files >= config[:warning_num].to_i
       warning "#{config[:directory]} has #{num_files} files (threshold: #{config[:warning_num]})"

--- a/spec/plugins/files/check_dir_count_spec.rb
+++ b/spec/plugins/files/check_dir_count_spec.rb
@@ -30,15 +30,15 @@ require 'plugin_stub'
 describe DirCount, 'run' do
 
   include_context :plugin_stub
-  
+
   ROOTDIR = 'spec/fixtures/plugins/files'
-  
+
   before(:all) do
-    ['another-sample-1', 'another-sample-2', 'another-sample-3', 'sample-1', 'sample-2', 'test-sample'].each do |foldername| 
+    %w[another-sample-1, another-sample-2, another-sample-3, sample-1, sample-2, test-sample].each do |foldername|
       FileUtils.mkdir_p "#{ROOTDIR}/#{foldername}"
     end
-  end 
-  
+  end
+
   describe '#directory' do
     it 'return unknown if given incorrect path to directory' do
       args = [
@@ -60,7 +60,7 @@ describe DirCount, 'run' do
     it 'return ok if given a correct path' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '10',
         '-c',
@@ -75,7 +75,7 @@ describe DirCount, 'run' do
     it 'return warning when number of files exceed threshold' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '6',
         '-c',
@@ -90,7 +90,7 @@ describe DirCount, 'run' do
     it 'return critical when number of files exceed threshold' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '1',
         '-c',
@@ -108,7 +108,7 @@ describe DirCount, 'run' do
     it 'return all files with default file pattern' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '10',
         '-c',
@@ -124,7 +124,7 @@ describe DirCount, 'run' do
     it 'return 3 matches that matches with another-sample* file_pattern' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '10',
         '-c',
@@ -142,7 +142,7 @@ describe DirCount, 'run' do
     it 'return 0 matches when given no-match-* file_pattern' do
       args = [
         '--dir',
-        'spec/fixtures/plugins/files',
+        ROOTDIR,
         '-w',
         '10',
         '-c',
@@ -159,6 +159,6 @@ describe DirCount, 'run' do
   end
 
   after(:all) do
-    FileUtils.rm_rf("#{ROOTDIR}")
+    FileUtils.rm_rf(ROOTDIR)
   end
 end

--- a/spec/plugins/files/check_dir_count_spec.rb
+++ b/spec/plugins/files/check_dir_count_spec.rb
@@ -5,7 +5,7 @@
 # DESCRIPTION:
 #   rspec testing to test the functionality of check_dir_count spec
 #   in particular the different combination of input options
-# 
+#
 # OUTPUT:
 #
 # PLATFORMS:
@@ -19,7 +19,7 @@
 # NOTES:
 #
 # LICENSE:
-#   Copyright 2015 Inny <mini.inny@gmail.com> 
+#   Copyright 2015 Inny <mini.inny@gmail.com>
 #   Released under the same terms as Sensu (the MIT license); see LICENSE
 #   for details.
 #
@@ -30,66 +30,123 @@ require 'plugin_stub'
 describe DirCount, 'run' do
 
   include_context :plugin_stub
-      
-  it 'return unknown if given incorrect path to directory' do 
-    args = [
-      '--dir',
-      'incorrect/path',
-      '-w',
-      '10',
-      '-c',
-      '20'
-    ]
-    check_dir = DirCount.new(args)
-    expected_output = "Error listing files in incorrect/path"
-    expect(check_dir).to receive('unknown').with(expected_output)
-    check_dir.run
-  end
-      
-  it 'return ok if given a correct path' do  
-    args = [
-      '--dir',
-      'spec/fixtures/plugins/files',
-      '-w',
-      '10',
-      '-c',
-      '20'
-    ]
-    check_dir = DirCount.new(args)
-    expected_output = "spec/fixtures/plugins/files has 6 files"
-    expect(check_dir).to receive('ok').with(expected_output) 
-    check_dir.run
+
+  describe '#directory' do
+    it 'return unknown if given incorrect path to directory' do
+      args = [
+        '--dir',
+        'incorrect/path',
+        '-w',
+        '10',
+        '-c',
+        '20'
+      ]
+      check_dir = DirCount.new(args)
+      expected_output = 'Error listing files in incorrect/path'
+      expect(check_dir).to receive('unknown').with(expected_output)
+      check_dir.run
+    end
   end
 
+  describe '#warning #critical' do
+    it 'return ok if given a correct path' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '10',
+        '-c',
+        '20'
+      ]
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 6 files'
+      expect(check_dir).to receive('ok').with(expected_output)
+      check_dir.run
+    end
 
-  it 'return warning when number of files exceed threshold' do 
-    args = [
-      '--dir',
-      'spec/fixtures/plugins/files',
-      '-w',
-      '6',
-      '-c',
-      '10'
-    ]
-    check_dir = DirCount.new(args)
-    expected_output = "spec/fixtures/plugins/files has 6 files (threshold: 6)"
-    expect(check_dir).to receive('warning').with(expected_output)
-    check_dir.run
+    it 'return warning when number of files exceed threshold' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '6',
+        '-c',
+        '10'
+      ]
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 6 files (threshold: 6)'
+      expect(check_dir).to receive('warning').with(expected_output)
+      check_dir.run
+    end
+
+    it 'return critical when number of files exceed threshold' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '1',
+        '-c',
+        '2'
+      ]
+
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 6 files (threshold: 2)'
+      expect(check_dir).to receive('critical').with(expected_output)
+      check_dir.run
+    end
   end
 
-  it 'return critical when number of files exceed threshold' do 
-    args = [
-      '--dir',
-      'spec/fixtures/plugins/files',
-      '-w',
-      '1',
-      '-c',
-      '2'
-    ]
+  describe '#file_pattern' do
+    it 'return all files with default file pattern' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '10',
+        '-c',
+        '20'
+      ]
 
-    check_dir = DirCount.new(args)
-    expected_output = "spec/fixtures/plugins/files has 6 files (threshold: 2)"
-    expect(check_dir).to receive('critical').with(expected_output)
-    check_dir.run
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 6 files'
+      expect(check_dir).to receive('ok').with(expected_output)
+      check_dir.run
+    end
+
+    it 'return 3 matches that matches with another-sample* file_pattern' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '10',
+        '-c',
+        '20',
+        '-p',
+        'another-sample*'
+      ]
+
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 3 files'
+      expect(check_dir).to receive('ok').with(expected_output)
+      check_dir.run
+    end
+
+    it 'return 0 matches when given no-match-* file_pattern' do
+      args = [
+        '--dir',
+        'spec/fixtures/plugins/files',
+        '-w',
+        '10',
+        '-c',
+        '20',
+        '-p',
+        'no-mathc-*'
+      ]
+
+      check_dir = DirCount.new(args)
+      expected_output = 'spec/fixtures/plugins/files has 0 files'
+      expect(check_dir).to receive('ok').with(expected_output)
+      check_dir.run
+    end
   end
 end

--- a/spec/plugins/files/check_dir_count_spec.rb
+++ b/spec/plugins/files/check_dir_count_spec.rb
@@ -30,7 +30,15 @@ require 'plugin_stub'
 describe DirCount, 'run' do
 
   include_context :plugin_stub
-
+  
+  ROOTDIR = 'spec/fixtures/plugins/files'
+  
+  before(:all) do
+    ['another-sample-1', 'another-sample-2', 'another-sample-3', 'sample-1', 'sample-2', 'test-sample'].each do |foldername| 
+      FileUtils.mkdir_p "#{ROOTDIR}/#{foldername}"
+    end
+  end 
+  
   describe '#directory' do
     it 'return unknown if given incorrect path to directory' do
       args = [
@@ -148,5 +156,9 @@ describe DirCount, 'run' do
       expect(check_dir).to receive('ok').with(expected_output)
       check_dir.run
     end
+  end
+
+  after(:all) do
+    FileUtils.rm_rf("#{ROOTDIR}")
   end
 end

--- a/spec/plugins/files/check_dir_count_spec.rb
+++ b/spec/plugins/files/check_dir_count_spec.rb
@@ -1,0 +1,95 @@
+#! /usr/bin/env ruby
+#
+#   check_dir_count_spec
+#
+# DESCRIPTION:
+#   rspec testing to test the functionality of check_dir_count spec
+#   in particular the different combination of input options
+# 
+# OUTPUT:
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   rspec
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Inny <mini.inny@gmail.com> 
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../../../plugins/files/check_dir_count'
+require 'plugin_stub'
+
+describe DirCount, 'run' do
+
+  include_context :plugin_stub
+      
+  it 'return unknown if given incorrect path to directory' do 
+    args = [
+      '--dir',
+      'incorrect/path',
+      '-w',
+      '10',
+      '-c',
+      '20'
+    ]
+    check_dir = DirCount.new(args)
+    expected_output = "Error listing files in incorrect/path"
+    expect(check_dir).to receive('unknown').with(expected_output)
+    check_dir.run
+  end
+      
+  it 'return ok if given a correct path' do  
+    args = [
+      '--dir',
+      'spec/fixtures/plugins/files',
+      '-w',
+      '10',
+      '-c',
+      '20'
+    ]
+    check_dir = DirCount.new(args)
+    expected_output = "spec/fixtures/plugins/files has 6 files"
+    expect(check_dir).to receive('ok').with(expected_output) 
+    check_dir.run
+  end
+
+
+  it 'return warning when number of files exceed threshold' do 
+    args = [
+      '--dir',
+      'spec/fixtures/plugins/files',
+      '-w',
+      '6',
+      '-c',
+      '10'
+    ]
+    check_dir = DirCount.new(args)
+    expected_output = "spec/fixtures/plugins/files has 6 files (threshold: 6)"
+    expect(check_dir).to receive('warning').with(expected_output)
+    check_dir.run
+  end
+
+  it 'return critical when number of files exceed threshold' do 
+    args = [
+      '--dir',
+      'spec/fixtures/plugins/files',
+      '-w',
+      '1',
+      '-c',
+      '2'
+    ]
+
+    check_dir = DirCount.new(args)
+    expected_output = "spec/fixtures/plugins/files has 6 files (threshold: 2)"
+    expect(check_dir).to receive('critical').with(expected_output)
+    check_dir.run
+  end
+end


### PR DESCRIPTION
- Adding a new option for the check dir count plugin so that we can specify the file patten that we would like to count. This is not mandatory and default to '*' so that it is backward compatible. 
- Rspec test are include to make sure the new option is backward compatible. 
- minor code change was made so that the unknown status can be detect in the rspec test