### PR TITLE
Sidekiq stats and check scripts

### DIFF
--- a/plugins/sidekiq/check-sidekiq.rb
+++ b/plugins/sidekiq/check-sidekiq.rb
@@ -32,31 +32,30 @@ require 'json'
 
 class SidekiqCheck < Sensu::Plugin::Check::CLI
   option :url,
-    short: '-u URL',
-    long: '--url URL',
-    description: 'Url to query',
-    required: true
+         short: '-u URL',
+         long: '--url URL',
+         description: 'Url to query',
+         required: true
 
   option :auth,
-    short: '-a USER:PASSWORD',
-    long: '--auth USER:PASSWORD',
-    description: 'Basic auth credentials if you need them',
-    proc: proc { |auth| auth.split(":") }
+         short: '-a USER:PASSWORD',
+         long: '--auth USER:PASSWORD',
+         description: 'Basic auth credentials if you need them',
+         proc: proc { |auth| auth.split(':') }
 
   option :warn,
-    short: '-w SECONDS',
-    long: '--warn SECONDS',
-    description: 'Warn after job has been SECONDS seconds in a queue',
-    proc: proc { |seconds| seconds.to_i },
-    default: 120
+         short: '-w SECONDS',
+         long: '--warn SECONDS',
+         description: 'Warn after job has been SECONDS seconds in a queue',
+         proc: proc { |seconds| seconds.to_i },
+         default: 120
 
   option :crit,
-    short: '-c SECONDS',
-    long: '--crit SECONDS',
-    description: 'Critical after job has been SECONDS seconds in a queue',
-    proc: proc { |seconds| seconds.to_i },
-    default: 300
-
+         short: '-c SECONDS',
+         long: '--crit SECONDS',
+         description: 'Critical after job has been SECONDS seconds in a queue',
+         proc: proc { |seconds| seconds.to_i },
+         default: 300
 
   def run
     begin
@@ -68,15 +67,15 @@ class SidekiqCheck < Sensu::Plugin::Check::CLI
         end
       )
 
-    rescue
-      unknown "Could not load Sidekiq stats from #{config[:url]}. Error: #{$!}"
+    rescue => error
+      unknown "Could not load Sidekiq stats from #{config[:url]}. Error: #{error}"
     end
 
     maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
-    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.inject(&:+) || 0
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.reduce(&:+) || 0
 
     if total_concurrency.zero?
-      critical "There are no Sidekiq workers"
+      critical 'There are no Sidekiq workers'
     end
 
     if maximum_latency > config[:warn]

--- a/plugins/sidekiq/check-sidekiq.rb
+++ b/plugins/sidekiq/check-sidekiq.rb
@@ -1,0 +1,90 @@
+#! /usr/bin/env ruby
+# encoding: UTF-8
+#   check-sidekiq
+#
+# DESCRIPTION:
+#   Check sidekiq status from a sidekiq-monitor-stats enabled endpoint.
+#
+#     https://github.com/harvesthq/sidekiq-monitor-stats
+#
+#   Uses the maximum latency to check the status.
+#
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: open-uri
+#   gem: json
+#
+# LICENSE:
+#   Albert Llop albert@getharvest.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/check/cli'
+require 'open-uri'
+require 'json'
+
+class SidekiqCheck < Sensu::Plugin::Check::CLI
+  option :url,
+    short: '-u URL',
+    long: '--url URL',
+    description: 'Url to query',
+    required: true
+
+  option :auth,
+    short: '-a USER:PASSWORD',
+    long: '--auth USER:PASSWORD',
+    description: 'Basic auth credentials if you need them',
+    proc: proc { |auth| auth.split(":") }
+
+  option :warn,
+    short: '-w SECONDS',
+    long: '--warn SECONDS',
+    description: 'Warn after job has been SECONDS seconds in a queue',
+    proc: proc { |seconds| seconds.to_i },
+    default: 120
+
+  option :crit,
+    short: '-c SECONDS',
+    long: '--crit SECONDS',
+    description: 'Critical after job has been SECONDS seconds in a queue',
+    proc: proc { |seconds| seconds.to_i },
+    default: 300
+
+
+  def run
+    begin
+      stats = JSON.parse(
+        if config[:auth]
+          open(config[:url], http_basic_authentication: config[:auth]).read
+        else
+          open(config[:url]).read
+        end
+      )
+
+    rescue
+      unknown "Could not load Sidekiq stats from #{config[:url]}. Error: #{$!}"
+    end
+
+    maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.inject(&:+) || 0
+
+    if total_concurrency.zero?
+      critical "There are no Sidekiq workers"
+    end
+
+    if maximum_latency > config[:warn]
+      warning "A job has been in a queue longer than #{config[:warn]} seconds"
+    elsif maximum_latency > config[:crit]
+      critical "A job has been in a queue longer than #{config[:crit]} seconds"
+    end
+
+    ok "Maximum job latency #{maximum_latency}"
+  end
+end

--- a/plugins/sidekiq/sidekiq-metrics.rb
+++ b/plugins/sidekiq/sidekiq-metrics.rb
@@ -1,0 +1,76 @@
+#! /usr/bin/env ruby
+# encoding: UTF-8
+#   sidekiq-metrics
+#
+# DESCRIPTION:
+#   Pull sidekiq metrics from a sidekiq-monitor-stats enabled endpoint.
+#
+#     https://github.com/harvesthq/sidekiq-monitor-stats
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: open-uri
+#   gem: json
+#
+# LICENSE:
+#   Albert Llop albert@getharvest.com
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+
+require 'sensu-plugin/metric/cli'
+require 'open-uri'
+require 'json'
+
+class SidekiqMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :url,
+    short: '-u URL',
+    long: '--url URL',
+    description: 'Url to query',
+    required: true
+
+  option :auth,
+    short: '-a USER:PASSWORD',
+    long: '--auth USER:PASSWORD',
+    description: 'Basic auth credentials if you need them',
+    proc: proc { |auth| auth.split(":") }
+
+  option :scheme,
+    description: 'Metric naming scheme, text to prepend to metric',
+    short: '-s SCHEME',
+    long: '--scheme SCHEME',
+    default: "sidekiq"
+
+  def run
+    begin
+      stats = JSON.parse(
+        if config[:auth]
+          open(config[:url], http_basic_authentication: config[:auth]).read
+        else
+          open(config[:url]).read
+        end
+      )
+
+    rescue
+      unknown "Could not load sidekiq stats from #{config[:url]}. Error: #{$!}"
+    end
+
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.inject(&:+) || 0
+    total_busy        = stats['processes'].map { |process| process['busy'] }.inject(&:+) || 0
+    maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
+
+    output "#{config[:scheme]}.concurrency", total_concurrency
+    output "#{config[:scheme]}.busy",        total_busy
+    output "#{config[:scheme]}.latency",     maximum_latency
+
+    ok
+  end
+end

--- a/plugins/sidekiq/sidekiq-metrics.rb
+++ b/plugins/sidekiq/sidekiq-metrics.rb
@@ -32,22 +32,22 @@ require 'json'
 
 class SidekiqMetrics < Sensu::Plugin::Metric::CLI::Graphite
   option :url,
-    short: '-u URL',
-    long: '--url URL',
-    description: 'Url to query',
-    required: true
+         short: '-u URL',
+         long: '--url URL',
+         description: 'Url to query',
+         required: true
 
   option :auth,
-    short: '-a USER:PASSWORD',
-    long: '--auth USER:PASSWORD',
-    description: 'Basic auth credentials if you need them',
-    proc: proc { |auth| auth.split(":") }
+         short: '-a USER:PASSWORD',
+         long: '--auth USER:PASSWORD',
+         description: 'Basic auth credentials if you need them',
+         proc: proc { |auth| auth.split(':') }
 
   option :scheme,
-    description: 'Metric naming scheme, text to prepend to metric',
-    short: '-s SCHEME',
-    long: '--scheme SCHEME',
-    default: "sidekiq"
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: 'sidekiq'
 
   def run
     begin
@@ -59,12 +59,12 @@ class SidekiqMetrics < Sensu::Plugin::Metric::CLI::Graphite
         end
       )
 
-    rescue
-      unknown "Could not load sidekiq stats from #{config[:url]}. Error: #{$!}"
+    rescue => error
+      unknown "Could not load sidekiq stats from #{config[:url]}. Error: #{error}"
     end
 
-    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.inject(&:+) || 0
-    total_busy        = stats['processes'].map { |process| process['busy'] }.inject(&:+) || 0
+    total_concurrency = stats['processes'].map { |process| process['concurrency'] }.reduce(&:+) || 0
+    total_busy        = stats['processes'].map { |process| process['busy'] }.reduce(&:+) || 0
     maximum_latency   = stats['queues'].map { |name, data| data['latency'] }.max
 
     output "#{config[:scheme]}.concurrency", total_concurrency


### PR DESCRIPTION
We use these scripts to monitor and gather stats from [sidekiq](https://github.com/mperham/sidekiq). They can load data from a [sidekiq-monitor-stats](https://github.com/harvesthq/sidekiq-monitor-stats) enabled endpoint. One just needs to install that gem in the running rails app and the endpoint is available. 

We're very happy with this solution because it warns us when things stop working or our sidekiq workers can't deal with the load, while being flexible enough to allow for some wiggle room (during deploys or other situations that aren't really critical). The metrics we gather let us very clearly see if and when we're going to need more capacity. 

I'll update that gem's README if this is merged.

Let me know if there's anything I need to update. I tried to follow the guidelines, though!

Thanks a lot for your time.