### PR TITLE
Value for SurgeQueueLength in statistic_type Fixed

### DIFF
--- a/plugins/aws/elb-full-metrics.rb
+++ b/plugins/aws/elb-full-metrics.rb
@@ -94,7 +94,7 @@ class ELBMetrics < Sensu::Plugin::Metric::CLI::Graphite
       'HTTPCode_ELB_4XX' => 'Sum',
       'HTTPCode_ELB_5XX' => 'Sum',
       'BackendConnectionErrors' => 'Sum',
-      'SurgeQueueLength' => 'Max',
+      'SurgeQueueLength' => 'Maximum',
       'SpilloverCount' => 'Sum'
     }
 


### PR DESCRIPTION
Run:
./elb-full-metrics.rb -n ELBName -r Region -s AWS

Error:
Error: exception: The parameter Statistics.member.1 must be a value in the set [ Sum, Maximum, Minimum, SampleCount, Average ].