### PR TITLE
Added support for nested keys in http-json-check

### DIFF
--- a/sensu-plugins.gemspec
+++ b/sensu-plugins.gemspec
@@ -14,32 +14,6 @@ Gem::Specification.new do |gem|
   gem.files                 = Dir['Rakefile', '{plugins,extensions,handlers,mutators,lib,spec,scripts}/**/*', 'README*', 'LICENSE*', 'CONTRIB*', 'CHANGELOG*']
 
   gem.add_dependency 'sensu-plugin', '1.1.0'
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-  # gem.add_dependency
-
   gem.add_development_dependency 'bundler',           '~> 1.3'
   gem.add_development_dependency 'rubocop',           '~> 0.17.0'
   gem.add_development_dependency 'rake'
@@ -51,6 +25,8 @@ Gem::Specification.new do |gem|
   # gem.add_development_dependency 'guard-rubocop',   '~> 1.0'
   gem.add_development_dependency 'rspec'
   gem.add_development_dependency 'rspec-mocks'
+  gem.add_development_dependency 'webmock'
+  gem.add_development_dependency 'pry'
   # gem.add_development_dependency 'ruby_gntp',       '~> 0.3.4'
   # gem.add_development_dependency 'simplecov',       '~> 0.7.1'
   # gem.add_development_dependency 'yard',            '~> 0.8'

--- a/spec/plugins/http/check_json_spec.rb
+++ b/spec/plugins/http/check_json_spec.rb
@@ -91,4 +91,18 @@ describe CheckJson, 'run' do
     json.run
   end
 
+  it 'should be able to check against a malformed nested json key/value and send a critical message' do
+    nested_json = "{\"toplevel\":{\"health\":\"good\"}}"
+    stub_with_webmock(nested_json)
+
+    json = CheckJson.new
+    json.config[:url] = "https://example.com:45699/health/check"
+    json.config[:key] = "no,such,key,path"
+    json.config[:value] = "WRONG"
+
+    expect(json).to receive(:critical).with("JSON key check failed")
+    json.run
+  end
+
+
 end

--- a/spec/plugins/http/check_json_spec.rb
+++ b/spec/plugins/http/check_json_spec.rb
@@ -1,0 +1,94 @@
+#! /usr/bin/env ruby
+#
+#   check-http-json_spec
+#
+# DESCRIPTION:
+#
+# OUTPUT:
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: check-http-json
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2014 Sonian, Inc. and contributors. <support@sensuapp.org>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../../../plugins/http/check-http-json'
+require_relative '../../../spec_helper'
+
+require 'webmock/rspec'
+
+describe CheckJson, 'run' do
+
+  before do
+    WebMock.disable_net_connect!(allow_localhost: true)
+  end
+
+  def stub_with_webmock(resp_json)
+    stub_request(:get, "https://example.com:45699/health/check").
+    with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
+    to_return(:status => 200, :body => resp_json, :headers => {"Content-type" => "application/json"})
+  end
+
+  it 'should be able to check against a flat json key/value pair and report ok successfully' do
+    json = "{\"health\":\"good\"}"
+    stub_with_webmock(json)
+
+    json = CheckJson.new
+    json.config[:url] = "https://example.com:45699/health/check"
+    json.config[:key] = "health"
+    json.config[:value] = "good"
+
+    expect(json).to receive(:ok).with("Valid JSON and key present and correct")
+    json.run
+  end
+
+  it 'should be able to check against a flat json key/value and send a critical message' do
+    json = "{\"health\":\"good\"}"
+    stub_with_webmock(json)
+
+    json = CheckJson.new
+    json.config[:url] = "https://example.com:45699/health/check"
+    json.config[:key] = "health"
+    json.config[:value] = "NOT-PRESENT-VALUE!"
+
+    expect(json).to receive(:critical).with("JSON key check failed")
+    json.run
+  end
+
+  it 'should be able to check against a nested json key/value and report ok successfully' do
+    nested_json = "{\"toplevel\":{\"health\":\"good\"}}"
+    stub_with_webmock(nested_json)
+
+    json = CheckJson.new
+    json.config[:url] = "https://example.com:45699/health/check"
+    json.config[:key] = "toplevel,health"
+    json.config[:value] = "good"
+
+    expect(json).to receive(:ok).with("Valid JSON and key present and correct")
+    json.run
+  end
+
+  it 'should be able to check against a nested json key/value and send a critical message' do
+    nested_json = "{\"toplevel\":{\"health\":\"good\"}}"
+    stub_with_webmock(nested_json)
+
+    json = CheckJson.new
+    json.config[:url] = "https://example.com:45699/health/check"
+    json.config[:key] = "toplevel"
+    json.config[:value] = "WRONG"
+
+    expect(json).to receive(:critical).with("JSON key check failed")
+    json.run
+  end
+
+end

--- a/spec/plugins/http/check_json_spec.rb
+++ b/spec/plugins/http/check_json_spec.rb
@@ -34,9 +34,9 @@ describe CheckJson, 'run' do
   end
 
   def stub_with_webmock(resp_json)
-    stub_request(:get, "https://example.com:45699/health/check").
-    with(:headers => {'Accept'=>'*/*', 'Accept-Encoding'=>'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent'=>'Ruby'}).
-    to_return(:status => 200, :body => resp_json, :headers => {"Content-type" => "application/json"})
+    stub_request(:get, 'https://example.com:45699/health/check')
+    .with(headers: { 'Accept' => '*/*', 'Accept-Encoding' => 'gzip;q=1.0,deflate;q=0.6,identity;q=0.3', 'User-Agent' => 'Ruby' })
+    .to_return(status: 200, body: resp_json, headers: { 'Content-type' => 'application/json' })
   end
 
   it 'should be able to check against a flat json key/value pair and report ok successfully' do
@@ -44,11 +44,11 @@ describe CheckJson, 'run' do
     stub_with_webmock(json)
 
     json = CheckJson.new
-    json.config[:url] = "https://example.com:45699/health/check"
-    json.config[:key] = "health"
-    json.config[:value] = "good"
+    json.config[:url] = 'https://example.com:45699/health/check'
+    json.config[:key] = 'health'
+    json.config[:value] = 'good'
 
-    expect(json).to receive(:ok).with("Valid JSON and key present and correct")
+    expect(json).to receive(:ok).with('Valid JSON and key present and correct')
     json.run
   end
 
@@ -57,11 +57,11 @@ describe CheckJson, 'run' do
     stub_with_webmock(json)
 
     json = CheckJson.new
-    json.config[:url] = "https://example.com:45699/health/check"
-    json.config[:key] = "health"
-    json.config[:value] = "NOT-PRESENT-VALUE!"
+    json.config[:url] = 'https://example.com:45699/health/check'
+    json.config[:key] = 'health'
+    json.config[:value] = 'NOT-PRESENT-VALUE!'
 
-    expect(json).to receive(:critical).with("JSON key check failed")
+    expect(json).to receive(:critical).with('JSON key check failed')
     json.run
   end
 
@@ -70,11 +70,11 @@ describe CheckJson, 'run' do
     stub_with_webmock(nested_json)
 
     json = CheckJson.new
-    json.config[:url] = "https://example.com:45699/health/check"
-    json.config[:key] = "toplevel,health"
-    json.config[:value] = "good"
+    json.config[:url] = 'https://example.com:45699/health/check'
+    json.config[:key] = 'toplevel,health'
+    json.config[:value] = 'good'
 
-    expect(json).to receive(:ok).with("Valid JSON and key present and correct")
+    expect(json).to receive(:ok).with('Valid JSON and key present and correct')
     json.run
   end
 
@@ -83,11 +83,11 @@ describe CheckJson, 'run' do
     stub_with_webmock(nested_json)
 
     json = CheckJson.new
-    json.config[:url] = "https://example.com:45699/health/check"
-    json.config[:key] = "toplevel"
-    json.config[:value] = "WRONG"
+    json.config[:url] = 'https://example.com:45699/health/check'
+    json.config[:key] = 'toplevel'
+    json.config[:value] = 'WRONG'
 
-    expect(json).to receive(:critical).with("JSON key check failed")
+    expect(json).to receive(:critical).with('JSON key check failed')
     json.run
   end
 
@@ -96,13 +96,12 @@ describe CheckJson, 'run' do
     stub_with_webmock(nested_json)
 
     json = CheckJson.new
-    json.config[:url] = "https://example.com:45699/health/check"
-    json.config[:key] = "no,such,key,path"
-    json.config[:value] = "WRONG"
+    json.config[:url] = 'https://example.com:45699/health/check'
+    json.config[:key] = 'no,such,key,path'
+    json.config[:value] = 'WRONG'
 
-    expect(json).to receive(:critical).with("JSON key check failed")
+    expect(json).to receive(:critical).with('JSON key check failed')
     json.run
   end
-
 
 end


### PR DESCRIPTION
- Added a spec for http-json-check.
- This requires webmock for dev dependency (gemspec file).
- Run the test with:

  `$ bundle install; bundle exec rspec spec/plugins/http/check_json_spec.rb`

- Ran the script manually with ruby/like the example, worked fine.
- Added example documentation with single key, as was before.
- Added example documentation with nested key form.
