### PR TITLE
Exclude errors in the conntrack shell output

### DIFF
--- a/plugins/system/conntrack-metrics.rb
+++ b/plugins/system/conntrack-metrics.rb
@@ -39,7 +39,7 @@ class Conntrack < Sensu::Plugin::Metric::CLI::Graphite
          default: 'conntrack'
 
   def run
-    value = `conntrack -C #{config[:table]}`.strip
+    value = `conntrack -C #{config[:table]}  2>/dev/null`.strip
     timestamp = Time.now.to_i
 
     output config[:scheme], value, timestamp


### PR DESCRIPTION
This keeps warning messages from being sent to graphite in addition to the metric values.