### PR TITLE
Remove an extra space and remove a ? for a gem

### DIFF
--- a/plugins/files/check-mtime.rb
+++ b/plugins/files/check-mtime.rb
@@ -13,7 +13,6 @@
 #
 # DEPENDENCIES:
 #   gem: sensu-plugin
-#   gem: <?>
 #
 # USAGE:
 #  #YELLOW

--- a/plugins/smart/smart.json
+++ b/plugins/smart/smart.json
@@ -16,6 +16,6 @@
       { "id": 199, "name": "UDMA_CRC_Error_Count" },
       { "id": 201, "name": "Unc_Soft_read_Err_Rate", "read": "left16bit" },
       { "id": 230, "name": "Life_Curve_Status", "crit_min": 100, "warn_min": 100, "warn_max": 100, "crit_max": 100 }
-    ] 
+    ]
   }
 }


### PR DESCRIPTION
The gem was in reference to the fileutils require, which built into ruby so there's no gem to specify there.