### PR TITLE
Sync RabbitMQ changes from the rabbitmq sensu plugin repo

### DIFF
--- a/plugins/rabbitmq/check-rabbitmq-messages.rb
+++ b/plugins/rabbitmq/check-rabbitmq-messages.rb
@@ -17,6 +17,7 @@
 #
 # LICENSE:
 # Copyright 2012 Evan Hazlett <ejhazlett@gmail.com>
+# Copyright 2015 Tim Smith <tim@cozy.co> and Cozy Services Ltd.
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
@@ -66,6 +67,26 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
          description: 'CRITICAL message count threshold',
          default: 500
 
+  option :queuelevel,
+         short: '-q',
+         long: '--queuelevel',
+         description: 'Monitors that no individual queue is above the thresholds specified'
+
+  option :excluded,
+         short: '-e queue_name',
+         long: '--excludedqueues queue_name',
+         description: 'Comma separated list of queues to exclude when using queue level monitoring',
+         proc: proc { |q| q.split(',') },
+         default: []
+
+  def generate_message(status_hash)
+    message =  []
+    status_hash.each_pair do |k, v|
+      message << "#{k}: #{v}"
+    end
+    message.join(', ')
+  end
+
   def acquire_rabbitmq_info
     begin
       rabbitmq_info = CarrotTop.new(
@@ -76,18 +97,32 @@ class CheckRabbitMQMessages < Sensu::Plugin::Check::CLI
         ssl: config[:ssl]
       )
     rescue
-      warning 'could not get rabbitmq info'
+      warning 'Could not connect to rabbitmq'
     end
     rabbitmq_info
   end
 
   def run
     rabbitmq = acquire_rabbitmq_info
-    overview = rabbitmq.overview
-    total = overview['queue_totals']['messages']
-    message "#{total}"
-    critical if total > config[:critical].to_i
-    warning if total > config[:warn].to_i
+
+    # monitor counts in each queue or monitor the total number of messages in the system
+    if config[:queuelevel]
+      warn_queues = {}
+      crit_queues = {}
+      rabbitmq.queues.each do |queue|
+        next if config[:excluded].include?(queue['name'])
+        (crit_queues["#{queue['name']}"] = queue['messages']; next) if queue['messages'] >= config[:critical].to_i # rubocop: disable Style/Semicolon
+        (warn_queues["#{queue['name']}"] = queue['messages']; next) if queue['messages'] >= config[:warn].to_i # rubocop: disable Style/Semicolon
+      end
+      message crit_queues.empty? ? generate_message(warn_queues) : generate_message(crit_queues)
+      critical unless crit_queues.empty?
+      warning unless warn_queues.empty?
+    else
+      total = rabbitmq.overview['queue_totals']['messages']
+      message "#{total}"
+      critical if total > config[:critical].to_i
+      warning if total > config[:warn].to_i
+    end
     ok
   end
 end

--- a/plugins/rabbitmq/rabbitmq-queue-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-queue-metrics.rb
@@ -100,7 +100,8 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       end
 
       # fetch the average egress rate of the queue
-      output([config[:scheme], queue['name'], 'avg_egress_rate'].join('.'), queue['backing_queue_status']['avg_egress_rate'], timestamp)
+      rate = sprintf('%.4f' % queue['backing_queue_status']['avg_egress_rate'])
+      output([config[:scheme], queue['name'], 'avg_egress_rate'].join('.'), rate, timestamp)
     end
     ok
   end

--- a/plugins/rabbitmq/rabbitmq-queue-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-queue-metrics.rb
@@ -100,7 +100,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
       end
 
       # fetch the average egress rate of the queue
-      rate = sprintf('%.4f' % queue['backing_queue_status']['avg_egress_rate'])
+      rate = format('%.4f', queue['backing_queue_status']['avg_egress_rate'])
       output([config[:scheme], queue['name'], 'avg_egress_rate'].join('.'), rate, timestamp)
     end
     ok


### PR DESCRIPTION
Avoid incredibly small egress numbers breaking graphite output
Allow monitoring all queues except those you exclude in the consumer count check
Allow specifying per queue message count thresholds vs. system level message count thresholds