### PR TITLE
Adding steal at the cpu metric

### DIFF
--- a/plugins/system/vmstat-metrics.rb
+++ b/plugins/system/vmstat-metrics.rb
@@ -78,7 +78,8 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
         user: result[12],
         system: result[13],
         idle: result[14],
-        waiting: result[15]
+        waiting: result[15],
+        waiting: result[16]
       }
     }
     metrics.each do |parent, children|

--- a/plugins/system/vmstat-metrics.rb
+++ b/plugins/system/vmstat-metrics.rb
@@ -50,6 +50,9 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
 
   def run
     result = convert_integers(`vmstat 1 2|tail -n1`.split(' '))
+    if result[16].nil?
+      result[16] = 0
+    end
     timestamp = Time.now.to_i
     metrics = {
       procs: {
@@ -79,7 +82,7 @@ class VMStat < Sensu::Plugin::Metric::CLI::Graphite
         system: result[13],
         idle: result[14],
         waiting: result[15],
-        waiting: result[16]
+        steal: result[16]
       }
     }
     metrics.each do |parent, children|


### PR DESCRIPTION
Almost all distros are already showing steal cpu.
I added it. In case of a system without steal cpu information it would be 0.