### PR TITLE
[CheckKannel] Add option to filter SMSC connections using a pattern

### DIFF
--- a/plugins/kannel/check-kannel.rb
+++ b/plugins/kannel/check-kannel.rb
@@ -50,6 +50,11 @@ class CheckKannel < Sensu::Plugin::Check::CLI
          long: '--password PASSWORD',
          description: 'Your Kannel password'
 
+  option :pattern,
+         short: '-i PATTERN',
+         long: '--id PATTERN',
+         description: 'Match a SMSC id against this pattern'
+
   def run
     path = "/status.xml?password=#{config[:password]}"
 
@@ -67,6 +72,8 @@ class CheckKannel < Sensu::Plugin::Check::CLI
     smscs_status = Hash[REXML::XPath.each(document, '//smsc').map do |smsc|
       [smsc.text('id'), smsc.text('status')]
     end]
+
+    smscs_status.reject! { |id, _| /#{config[:pattern]}/ !~ id } if config[:pattern]
 
     offline_smscs = smscs_status.reject { |_, status| status.start_with? 'online' }.keys
 


### PR DESCRIPTION
We are currently using this plugin to monitor our Kannel instance. This option was required and we thought of keeping the plugin updated here.
