### PR TITLE
import basic nagios checks for FreeBSD system checks

### DIFF
--- a/plugins/freebsd/check-freebsd-kernel.sh
+++ b/plugins/freebsd/check-freebsd-kernel.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+
+# this needs FreeBSD > 10.0 as it introduces the freebsd-version command
+
+HAS_FREEBSD_VERSION=$(which freebsd-version)
+
+if [ -z ${HAS_FREEBSD_VERSION} ]; then
+  echo "Only FreeBSD > 10.0 is supported."
+  exit 3
+fi
+
+RUNNING_KERNEL=$(uname -r)
+INSTALLED_KERNEL=$(freebsd-version -k)
+
+if [ "z${RUNNING_KERNEL}" == "z${INSTALLED_KERNEL}" ]; then
+  echo "FreeBSD kernel ${RUNNING_KERNEL} up to date."
+  exit 0
+else
+  echo "FreeBSD running kernel is ${RUNNING_KERNEL} and should be ${INSTALLED_KERNEL}."
+  exit 2
+fi

--- a/plugins/freebsd/check-freebsd-update.sh
+++ b/plugins/freebsd/check-freebsd-update.sh
@@ -2,6 +2,13 @@
 
 # this needs to run with sudo as the tag file is only readable by root
 
+HAS_FREEBSD_VERSION=$(which freebsd-version)
+
+if [ -z ${HAS_FREEBSD_VERSION} ]; then
+  echo "Only FreeBSD > 10.0 is supported."
+  exit 3
+fi
+
 TAGFILE="/var/db/freebsd-update/tag"
 
 if [ ! -f ${TAGFILE} ]; then

--- a/plugins/freebsd/check-freebsd-update.sh
+++ b/plugins/freebsd/check-freebsd-update.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+
+# this needs to run with sudo as the tag file is only readable by root
+
+TAGFILE="/var/db/freebsd-update/tag"
+
+if [ ! -f ${TAGFILE} ]; then
+  echo "Couldn't find ${TAGFILE} to check for version."
+  exit 3
+fi
+
+CURRENT_VERSION=$(/bin/freebsd-version)
+UPDATE_BASE=$(cut -f 3 -d '|' < ${TAGFILE})
+UPDATE_PATCH=$(cut -f 4 -d '|' < ${TAGFILE})
+UPDATE_VERSION="${UPDATE_BASE}-p${UPDATE_PATCH}"
+
+if [ "z${CURRENT_VERSION}" == "z${UPDATE_VERSION}" ]; then
+  echo "FreeBSD installation up-to-date on ${CURRENT_VERSION}."
+  exit 0
+else
+  echo "FreeBSD installation is on ${CURRENT_VERSION} and should be on ${UPDATE_VERSION}."
+  exit 2
+fi

--- a/plugins/freebsd/check-pkg-audit.sh
+++ b/plugins/freebsd/check-pkg-audit.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+# check to figure out if packages need to be updated
+
+NUMBER=$(pkg audit -q | wc -l | sed -e "s/ //g")
+
+if [ ${NUMBER} -gt 0 ] ; then
+  echo "There are ${NUMBER} vulnerable packages: $(pkg audit -q)"
+  exit 2
+else
+  echo "There are no vulnerable packages."
+  exit 0
+fi

--- a/plugins/freebsd/check-zpool.sh
+++ b/plugins/freebsd/check-zpool.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# check for zpool health
+ZPOOL=`which zpool`
+EXITSTATUS=0
+IFS=$'\n'
+
+for line in $(${ZPOOL} list -o name,health | grep -v NAME | grep -v ONLINE)
+do
+  echo $line
+  EXITSTATUS=2
+done
+
+if [ $EXITSTATUS == 0 ]; then
+  echo "All pools are healthy."
+fi
+
+exit $EXITSTATUS


### PR DESCRIPTION
These are some basic checks I use with nagios on different FreeBSD systems.
It's mostly to check that systems are up to date and don't run a faulty
configuration for base setups.

The checks are all written in shell script against the base `/bin/sh` to work on a default FreeBSD system. I'm not sure if that's ok for the sensu plugins or if they should be written in Ruby. There is no real reason why they couldn't and I wouldn't be opposed to converting them (if I find the time :).

Feedback on all things layout, style, documentation and better ways to do those checks highly appreciated. 
