### PR TITLE
Added configurable prefix in mail notification subject

### DIFF
--- a/handlers/notification/README.md
+++ b/handlers/notification/README.md
@@ -10,6 +10,8 @@ The following three configuration variables must be set if you want mailer to us
 
 There is an optional subscriptions hash which can be added to your mailer.json file.  This subscriptions hash allows you to define individual mail_to addresses for a given subscription.  When the mailer handler runs it will check the clients subscriptions and build a mail_to string with the default mailer.mail_to address as well as any subscriptions the client subscribes to where a mail_to address is found.  There can be N number of hashes inside of subscriptions but the key for a given hash inside of subscriptions must match a subscription name. 
 
+Also there is an optional variable `subject_tag` which defines a tag in the mail subject. The tag will be prepended to subject. Useful to tag mails from different sources.
+
 ```json
 {
   "mailer": {

--- a/handlers/notification/mailer.json
+++ b/handlers/notification/mailer.json
@@ -5,6 +5,7 @@
     "mail_to": "monitor@example.com",
     "smtp_address": "smtp.example.org",
     "smtp_port": "25",
-    "smtp_domain": "example.org"
+    "smtp_domain": "example.org",
+    "subject_tag": ""
   }
 }

--- a/handlers/notification/mailer.rb
+++ b/handlers/notification/mailer.rb
@@ -78,6 +78,7 @@ class Mailer < Sensu::Handler
     mail_to = build_mail_to_list
     mail_from =  settings[json_config]['mail_from']
     reply_to = settings[json_config]['reply_to'] || mail_from
+    subject_tag = settings[json_config]['subject_tag'] || ''
 
     delivery_method = settings[json_config]['delivery_method'] || 'smtp'
     smtp_address = settings[json_config]['smtp_address'] || 'localhost'
@@ -106,9 +107,9 @@ class Mailer < Sensu::Handler
             #{playbook}
           BODY
     if @event['check']['notification'].nil?
-      subject = "#{action_to_string} - #{short_name}: #{status_to_string}"
+      subject = "#{subject_tag}#{action_to_string} - #{short_name}: #{status_to_string}"
     else
-      subject = "#{action_to_string} - #{short_name}: #{@event['check']['notification']}"
+      subject = "#{subject_tag}#{action_to_string} - #{short_name}: #{@event['check']['notification']}"
     end
 
     Mail.defaults do


### PR DESCRIPTION
Includes a configurable prefix in the notification mail subject. Useful when there are several Sensu installations and needs to differentiate mail notifications by subject.