### PR TITLE
Changed method for determining version of free

### DIFF
--- a/plugins/system/check-mem.sh
+++ b/plugins/system/check-mem.sh
@@ -41,7 +41,7 @@ fi
 WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
-if [ -f /etc/redhat-release ] && [ `awk '{print $3}' /etc/redhat-release` = "21" ]; then
+if [ $(free -m |grep -c available) -ne 0 ]; then
   FREE_MEMORY=`free -m | grep Mem | awk '{ print $7 }'`
 else
   FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`


### PR DESCRIPTION
Instead of using redhat version, use free output to determine
how to parse the results
