### PR TITLE
check-http: fix ssl verification

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -40,6 +40,9 @@ class HipChatNotif < Sensu::Handler
   end
 
   def handle
+    # skip OK handler calls in checks with type == 'metric'
+    return if @event['check']['status'] == 0 and not @event['action'].eql?('resolve')
+
     json_config = config[:json_config] || 'hipchat'
     server_url = settings[json_config]['server_url'] || 'https://api.hipchat.com'
     apiversion = settings[json_config]['apiversion'] || 'v1'

--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -211,6 +211,7 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
           if ssl_context.current_cert.not_after <= expire_warn_date
             warn_cert_expire = ssl_context.current_cert.not_after
           end
+          _preverify_ok
         end
       end
     end

--- a/plugins/system/load-metrics.rb
+++ b/plugins/system/load-metrics.rb
@@ -58,7 +58,7 @@ class LoadStat < Sensu::Plugin::Metric::CLI::Graphite
   end
 
   def run
-    result = `uptime`.gsub(',', '').split(' ')
+    result = `LC_NUMERIC=C uptime`.gsub(',', '').split(' ')
     result = result[-3..-1]
 
     timestamp = Time.now.to_i


### PR DESCRIPTION
The original verification status must be be passed along in the
verification callback, otherwise the null return will cause a failure of
the SSL verification.
