### PR TITLE
modified influxdb-metrics to output full name and metric

### DIFF
--- a/handlers/metrics/influxdb-metrics.rb
+++ b/handlers/metrics/influxdb-metrics.rb
@@ -14,20 +14,21 @@ class SensuToInfluxDB < Sensu::Handler
     influxdb_pass   = settings['influxdb']['password']
     influxdb_db     = settings['influxdb']['database']
 
-    influxdb_data = InfluxDB::Client.new influxdb_db, :host => influxdb_server,
-                                                      :username => influxdb_user,
-                                                      :password => influxdb_pass,
-                                                      :port => influxdb_port,
-                                                      :server => influxdb_server
+    influxdb_data = InfluxDB::Client.new influxdb_db, host: influxdb_server,
+                                                      username: influxdb_user,
+                                                      password: influxdb_pass,
+                                                      port: influxdb_port,
+                                                      server: influxdb_server
     mydata = []
-    @event['check']['output'].each do |metric|
+    @event['check']['output'].each_line do |metric|
       m = metric.split
-      next unless m.count == 3
-      key = m[0].split('.', 2)[1]
+      next unless m.count >= 3
+      key = m[0].split('.', 1)[0]
+      next unless key
       key.gsub!('.', '_')
       value = m[1].to_f
-      mydata = {:host => @event['client']['name'], :value => value,
-                :ip => @event['client']['address']
+      mydata = { host: @event['client']['name'], value: value,
+                 ip: @event['client']['address']
                }
       influxdb_data.write_point(key, mydata)
     end


### PR DESCRIPTION
This modification changed so that the full name of the system is added as the metric instead of part of it.