### PR TITLE
Check for invalid utf8 chars.

### DIFF
--- a/plugins/system/check-hardware-fail.rb
+++ b/plugins/system/check-hardware-fail.rb
@@ -30,12 +30,16 @@ require 'sensu-plugin/check/cli'
 
 class CheckHardwareFail < Sensu::Plugin::Check::CLI
   def run
-    errors = `dmesg`.lines.grep(/\[Hardware Error\]/)
+    errors = dmesg_input.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '').lines.grep(/\[Hardware Error\]/)
     # #YELLOW
     unless errors.empty?  # rubocop:disable IfUnlessModifier
       critical 'Hardware Error Detected'
     end
 
     ok 'Hardware OK'
+  end
+
+  def dmesg_input
+    `dmesg`
   end
 end

--- a/spec/plugins/system/check-hardware-fail.rb
+++ b/spec/plugins/system/check-hardware-fail.rb
@@ -1,0 +1,25 @@
+require File.expand_path('../../../../plugins/system/check-hardware-fail', __FILE__)
+
+require 'plugin_stub'
+
+describe CheckHardwareFail do
+  include_context :plugin_stub
+  let(:checker) { described_class.new }
+
+  before(:each) do
+    def checker.dmesg_input
+      # https://robots.thoughtbot.com/fight-back-utf-8-invalid-byte-sequences
+      "hi \255"
+    end
+    def checker.ok(*args)
+      'ok notification'
+    end
+    def checker.critical(*args)
+      'critical notification'
+    end
+  end
+
+  it 'will not bomb out if there are invalid utf8 chars in dmesg' do
+    expect { checker.run }.not_to raise_error
+  end
+end


### PR DESCRIPTION
if `dmesg` comes up with invalid utf8 chars, the sensu check bombs out with the infamous

``` ruby
Failure/Error: 
   ArgumentError:
     invalid byte sequence in UTF-8
```

This should fix it.
