### PR TITLE
Pingdom accounts option

### DIFF
--- a/plugins/pingdom/check-pingdom-credits.rb
+++ b/plugins/pingdom/check-pingdom-credits.rb
@@ -71,6 +71,10 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
          short: '-t SECS',
          default: 10
 
+  option :account_email,
+         short: '-e ACCOUNT_EMAIL',
+         long:  '--account-email ACCOUNT_EMAIL'
+
   def run
     check_sms!
     check_checks! # LOL @ name clashes
@@ -115,12 +119,20 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
     @credits ||= api_call[:credits]
   end
 
+  def headers
+    if config[:account_email]
+      { 'App-Key' => config[:application_key], 'Account-Email' => config[:account_email] }
+    else
+      { 'App-Key' => config[:application_key] }
+    end
+  end
+
   def api_call
     resource = RestClient::Resource.new(
       'https://api.pingdom.com/api/2.0/credits',
       user: config[:user],
       password: config[:password],
-      headers: { 'App-Key' => config[:application_key] },
+      headers: headers,
       timeout: config[:timeout]
     )
     JSON.parse(resource.get, symbolize_names: true)

--- a/plugins/pingdom/check-pingdom-credits.rb
+++ b/plugins/pingdom/check-pingdom-credits.rb
@@ -48,7 +48,7 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
          short: '-k APP_KEY',
          long: '--application-key APP_KEY',
          required: true
-
+  
   option :warn_sms,
          long: '--warn-available-sms COUNT',
          default: 10,
@@ -69,7 +69,8 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
 
   option :timeout,
          short: '-t SECS',
-         default: 10
+         default: 10,
+         proc: proc(&:to_i)
 
   option :account_email,
          short: '-e ACCOUNT_EMAIL',


### PR DESCRIPTION
Pingdom has a multi-user-authentication option, whereby you can add a secondary restricted account and then query the team's account with it. This commit adds the option to send the email header for this option

It also changes the timeout option to an integer, because things
