### PR TITLE
fix httpparty error

### DIFF
--- a/handlers/notification/hipchat.rb
+++ b/handlers/notification/hipchat.rb
@@ -27,6 +27,7 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
 require 'hipchat'
 require 'timeout'
+require 'erb'
 
 class HipChatNotif < Sensu::Handler
   option :json_config,


### PR DESCRIPTION
I needed to add `require 'erb'` in order to avoid the an httparty error:
`httparty-0.13.4/lib/httparty/hash_conversions.rb:33:in `normalize_param': uninitialized constant HTTParty::HashConversions::ERB (NameError)`

The line in question is: https://github.com/jnunemaker/httparty/blob/master/lib/httparty/hash_conversions.rb#L33