### PR TITLE
added settingsname and routingkey arguments

### DIFF
--- a/handlers/notification/victorops.rb
+++ b/handlers/notification/victorops.rb
@@ -30,10 +30,10 @@ class VictorOps < Sensu::Handler
 
   def handle
     # validate that we have settings
-    if ! defined? settings[config[:settingsname]] || settings[config[:settingsname]] == nil
+    unless defined? settings[config[:settingsname]] && !settings[config[:settingsname]].nil?
       fail "victorops.rb sensu setting '#{config[:settingsname]}' not found or empty"
     end
-    if ! defined? settings[config[:settingsname]]['api_url'] || settings[config[:settingsname]]['api_url'] == nil
+    unless defined? settings[config[:settingsname]]['api_url'] && !settings[config[:settingsname]]['api_url'].nil?
       fail "victorops.rb sensu setting '#{config[:settingsname]}.api_url' not found or empty"
     end
     api_url = settings[config[:settingsname]]['api_url']
@@ -42,7 +42,7 @@ class VictorOps < Sensu::Handler
     routing_key = config[:routing_key]
     routing_key = settings[config[:settingsname]]['routing_key'] if routing_key.nil?
 
-    if ! defined? routing_key || routing_key.nil?
+    unless defined? routing_key && !routing_key.nil?
       fail 'routing key not defined, should be in Sensu settings or passed via command arguments'
     end
 

--- a/handlers/notification/victorops.rb
+++ b/handlers/notification/victorops.rb
@@ -3,7 +3,7 @@
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
-# 
+#
 # arguments:
 #   - settingsname: Sensu settings name, defaults to victorops
 #   - routingkey: VictorOps routing key
@@ -30,11 +30,11 @@ class VictorOps < Sensu::Handler
 
   def handle
     # validate that we have settings
-    if not defined? settings[config[:settingsname]] or settings[config[:settingsname]] == nil
-      raise "victorops.rb sensu setting '#{config[:settingsname]}' not found or empty"
+    if ! defined? settings[config[:settingsname]] || settings[config[:settingsname]] == nil
+      fail "victorops.rb sensu setting '#{config[:settingsname]}' not found or empty"
     end
-    if not defined? settings[config[:settingsname]]['api_url'] or settings[config[:settingsname]]['api_url'] == nil
-      raise "victorops.rb sensu setting '#{config[:settingsname]}.api_url' not found or empty"
+    if ! defined? settings[config[:settingsname]]['api_url'] || settings[config[:settingsname]]['api_url'] == nil
+      fail "victorops.rb sensu setting '#{config[:settingsname]}.api_url' not found or empty"
     end
     api_url = settings[config[:settingsname]]['api_url']
 
@@ -42,8 +42,8 @@ class VictorOps < Sensu::Handler
     routing_key = config[:routing_key]
     routing_key = settings[config[:settingsname]]['routing_key'] if routing_key.nil?
 
-    if not defined? routing_key or routing_key.nil?
-      raise "routing key not defined, should be in Sensu settings or passed via command arguments"
+    if ! defined? routing_key || routing_key.nil?
+      fail 'routing key not defined, should be in Sensu settings or passed via command arguments'
     end
 
     incident_key = @event['client']['name'] + '/' + @event['check']['name']

--- a/handlers/notification/victorops.rb
+++ b/handlers/notification/victorops.rb
@@ -3,6 +3,10 @@
 #
 # Released under the same terms as Sensu (the MIT license); see LICENSE
 # for details.
+# 
+# arguments:
+#   - settingsname: Sensu settings name, defaults to victorops
+#   - routingkey: VictorOps routing key
 
 require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-handler'
@@ -12,8 +16,36 @@ require 'net/https'
 require 'json'
 
 class VictorOps < Sensu::Handler
+  option :settingsname,
+         description: 'Sensu settings name',
+         short: '-n NAME',
+         long: '--name NAME',
+         default: 'victorops'
+
+  option :routing_key,
+         description: 'Routing key',
+         short: '-r KEY',
+         long: '--routingkey KEY',
+         default: nil
+
   def handle
-    config = settings['victorops']
+    # validate that we have settings
+    if not defined? settings[config[:settingsname]] or settings[config[:settingsname]] == nil
+      raise "victorops.rb sensu setting '#{config[:settingsname]}' not found or empty"
+    end
+    if not defined? settings[config[:settingsname]]['api_url'] or settings[config[:settingsname]]['api_url'] == nil
+      raise "victorops.rb sensu setting '#{config[:settingsname]}.api_url' not found or empty"
+    end
+    api_url = settings[config[:settingsname]]['api_url']
+
+    # validate that we have a routing key - command arguments take precedence
+    routing_key = config[:routing_key]
+    routing_key = settings[config[:settingsname]]['routing_key'] if routing_key.nil?
+
+    if not defined? routing_key or routing_key.nil?
+      raise "routing key not defined, should be in Sensu settings or passed via command arguments"
+    end
+
     incident_key = @event['client']['name'] + '/' + @event['check']['name']
 
     description = @event['check']['notification']
@@ -47,7 +79,7 @@ class VictorOps < Sensu::Handler
         payload[:check] = @event['check']
         payload[:client] = @event['client']
 
-        uri   = URI("#{config['api_url'].chomp('/')}/#{config['routing_key']}")
+        uri   = URI("#{api_url.chomp('/')}/#{routing_key}")
         https = Net::HTTP.new(uri.host, uri.port)
 
         https.use_ssl = true


### PR DESCRIPTION
Added settingsname and routingkey arguments to allow for multiple routing keys and accounts

Or having default settings within the victorops.json settings for api_url and routing_key and override with a different routing key in the handler definition

Also added some checks if required values not set
