### PR TITLE
Update ec2-count-metrics.rb

### DIFF
--- a/plugins/aws/ec2-count-metrics.rb
+++ b/plugins/aws/ec2-count-metrics.rb
@@ -61,7 +61,7 @@ class EC2Metrics < Sensu::Plugin::Metric::CLI::Graphite
 
   def aws_config
     hash = {}
-    hash.update access_key_id: config[:access_key_id], secret_access_key: config[:secret_access_key] if config[:access_key_id] && config[:secret_access_key]
+    hash.update access_key_id: config[:aws_access_key], secret_access_key: config[:aws_secret_access_key] if config[:aws_access_key] && config[:aws_secret_access_key]
     hash.update region: config[:aws_region]
     hash
   end


### PR DESCRIPTION
There is a typo inside the names of the options for the aws access key ID and secret.
The correction is attached.

Steve