### PR TITLE
Add metrics-chrony

### DIFF
--- a/plugins/chrony/metrics-chrony.rb
+++ b/plugins/chrony/metrics-chrony.rb
@@ -62,7 +62,7 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
       key, value = line.split(/\s*:\s*/)
       key = snakecase(key)
       next if value.nil?
-      digits = (value.match(/^-?\d+(\.\d+)?\s/) || [])[0]
+      digits = (value.match(/^(\+|-)?\d+(\.\d+)?\s/) || [])[0]
       number = digits ? digits.to_f : nil
       if key == 'system_time' && /slow/ =~ value
         number = - number

--- a/plugins/chrony/metrics-chrony.rb
+++ b/plugins/chrony/metrics-chrony.rb
@@ -1,0 +1,78 @@
+#! /usr/bin/env ruby
+#  encoding: UTF-8
+#
+#   metrics-chrony
+#
+# DESCRIPTION:
+#
+# OUTPUT:
+#   metric data
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#   gem: socket
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Mitsutoshi Aoe <maoe@foldr.in>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require 'sensu-plugin/metric/cli'
+require 'socket'
+
+class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
+  option :host,
+         description: 'Chrony host',
+         short: '-h HOST',
+         long: '--host HOST',
+         default: 'localhost'
+
+  option :scheme,
+         description: 'Metric naming scheme, text to prepend to metric',
+         short: '-s SCHEME',
+         long: '--scheme SCHEME',
+         default: Socket.gethostname
+
+  def run
+    config[:scheme] = config[:host] unless config[:host] == 'localhost'
+
+    tracking = get_tracking(config)
+    critical "Failed to get chrony stats from #{config[:host]}" if tracking.empty?
+    metrics = {
+      tracking: tracking
+    }
+    metrics.each do |name, stats|
+      stats.each do |key, value|
+        output([config[:scheme], name, key].join('.'), value)
+      end
+    end
+    ok
+  end
+
+  def get_tracking(config)
+    `chronyc tracking`.each_line.reduce({}) do |r, line|
+      key, value = line.split(/\s*:\s*/)
+      key = snakecase(key)
+      next if value.nil?
+      digits = (value.match(/^-?\d+(\.\d+)?\s/) || [])[0]
+      number = digits ? digits.to_f : nil
+      if key == 'system_time' && /slow/ =~ value
+        number = - number
+      end
+      r[key] = number if number
+      r
+    end
+  end
+
+  def snakecase(str)
+    str.downcase.gsub(/ /, '_').gsub(/[()]/, '')
+  end
+end

--- a/plugins/chrony/metrics-chrony.rb
+++ b/plugins/chrony/metrics-chrony.rb
@@ -62,8 +62,8 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
       key, value = line.split(/\s*:\s*/)
       next(r) if value.nil?
       key = snakecase(key)
-      matches = value.match(/^[+-]?\d+(\.\d+)?\s/) or next(r)
-      digits = matches[0] or next(r)
+      next(r) unless matches = value.match(/^[+-]?\d+(\.\d+)?\s/)
+      digits = matches[0]
       number = digits.to_f
       number = - number if /slow/ =~ value
       r[key] = number

--- a/plugins/chrony/metrics-chrony.rb
+++ b/plugins/chrony/metrics-chrony.rb
@@ -51,7 +51,7 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
     }
     metrics.each do |name, stats|
       stats.each do |key, value|
-        output([config[:scheme], name, key].join('.'), value)
+        output([config[:scheme], 'chrony', name, key].join('.'), value)
       end
     end
     ok

--- a/plugins/chrony/metrics-chrony.rb
+++ b/plugins/chrony/metrics-chrony.rb
@@ -60,9 +60,9 @@ class ChronyMetrics < Sensu::Plugin::Metric::CLI::Graphite
   def get_tracking(config)
     `chronyc tracking`.each_line.reduce({}) do |r, line|
       key, value = line.split(/\s*:\s*/)
-      next(r) if value.nil?
+      next r if value.nil?
       key = snakecase(key)
-      next(r) unless matches = value.match(/^[+-]?\d+(\.\d+)?\s/)
+      matches = value.match(/^[+-]?\d+(\.\d+)?\s/) || (next r)
       digits = matches[0]
       number = digits.to_f
       number = - number if /slow/ =~ value


### PR DESCRIPTION
This PR introduces a new metrics plugin for [Chrony](http://chrony.tuxfamily.org/). It replicates the behavior of [metrics-ntpstats](https://github.com/sensu-plugins/sensu-plugins-ntp/blob/master/bin/metrics-ntpstats.rb).
