### PR TITLE
Add ability to print whole response in check-http

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,7 @@ node_modules
 scripts/tech_debt.rb
 .vagrant/*
 *.gem
+
+#Intellij files
+*.iml
+*.idea

--- a/plugins/http/check-http.rb
+++ b/plugins/http/check-http.rb
@@ -129,6 +129,13 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
          long: '--redirect-to URL',
          description: 'Redirect to another page'
 
+  option :whole_response,
+         short: '-w',
+         long: '--whole-response',
+         description: 'Print whole output when check fails',
+         boolean: true,
+         default: false
+
   option :response_bytes,
          short: '-b BYTES',
          long: '--response-bytes BYTES',
@@ -228,10 +235,14 @@ class CheckHTTP < Sensu::Plugin::Check::CLI
     end
     res = http.request(req)
 
-    if config[:response_bytes]
-      body = "\n" + res.body[0..config[:response_bytes]]
+    if config[:whole_response]
+      body = "\n" + res.body
     else
-      body = ''
+      if config[:response_bytes]
+        body = "\n" + res.body[0..config[:response_bytes]]
+      else
+        body = ''
+      end
     end
 
     if config[:require_bytes] && res.body.length != config[:require_bytes]


### PR DESCRIPTION
This PR is a proposition of two changes:
- Add the ```-w``` or ```--whole-response``` to the ```check-http.rb``` check. When the check is failing, the whole message received will be displayed in the message
- Add the intellij project files to ignored in gitignore.