### PR TITLE
fix redhat-version for fedora and rhel for check-mem.sh

### DIFF
--- a/plugins/system/check-mem.sh
+++ b/plugins/system/check-mem.sh
@@ -41,7 +41,16 @@ fi
 WARN=${WARN:=0}
 CRIT=${CRIT:=0}
 
-if [ -f /etc/redhat-release ] && [ `awk '{print $3}' /etc/redhat-release` = "21" ]; then
+# validate fedora > 20 and rhel > 7.0
+if [[ `awk '{print $3}' /etc/redhat-release` =~ ^2[0-9]{1} ]]; then
+   redhat_version=1
+elif [[ `awk '{print $7}' /etc/redhat-version` =~ ^7\.[0-9]{1} ]]; then
+   redhat_version=1
+else
+   redhat_version=0
+fi
+
+if [ -f /etc/redhat-release ] && [ $redhat_version = '1' ] ; then
   FREE_MEMORY=`free -m | grep Mem | awk '{ print $7 }'`
 else
   FREE_MEMORY=`free -m | grep buffers/cache | awk '{ print $4 }'`


### PR DESCRIPTION
* add regexp to be able to match fedora (> 20)or rhel (> 7.0), without
this patch, if not possible to use this plugins on rhel