### PR TITLE
Add check-file-size.rb Files plugin

### DIFF
--- a/plugins/files/check-file-size.rb
+++ b/plugins/files/check-file-size.rb
@@ -31,7 +31,6 @@ require 'rubygems' if RUBY_VERSION < '1.9.0'
 require 'sensu-plugin/check/cli'
 
 class CheckFileSize < Sensu::Plugin::Check::CLI
-  attr_accessor :file_size
 
   option :file,
          description: 'file to stat (full path)',

--- a/plugins/files/check-file-size.rb
+++ b/plugins/files/check-file-size.rb
@@ -1,0 +1,102 @@
+#! /usr/bin/env ruby
+#
+#   check-file-size
+#
+# DESCRIPTION:
+#   Checks the file size of a given file.
+#   Optional command line parameters to ignore missing files
+#
+# OUTPUT:
+#   plain text
+#
+# PLATFORMS:
+#   Linux, BSD
+#
+# DEPENDENCIES:
+#   gem: sensu-plugin
+#
+# USAGE:
+#   check-file-size.rb --file <filename>
+#                      [--warn <size, in bytes, to warn on>]
+#                      [--critical <size, in bytes, to go CRITICAL on>]
+#                      [--ignore_missing]
+#                      [--debug]
+#
+# LICENSE:
+#   Copyright 2015 Jayson Sperling (jayson.sperling@sendgrid.com)
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+require 'rubygems' if RUBY_VERSION < '1.9.0'
+require 'sensu-plugin/check/cli'
+
+class CheckFileSize < Sensu::Plugin::Check::CLI
+  attr_accessor :file_size
+
+  option :file,
+    :description => 'file to stat (full path)',
+    :short => '-f',
+    :long => '--file FILENAME',
+    :required => true
+
+  option :warn,
+    :description => 'The size (in bytes) of the file where WARNING is raised',
+    :short => '-w SIZE',
+    :long => '--warn SIZE',
+    :proc => proc(&:to_i),
+    :default => 2_000_000
+
+  option :crit,
+    :description => 'The size (in bytes) of the file where CRITICAL is raised',
+    :short => '-c SIZE',
+    :long => '--critical SIZE',
+    :proc => proc(&:to_i),
+    :default => 3_000_000
+
+  option :ignore_missing,
+    :short => '-i',
+    :long => '--ignore-missing',
+    :description => 'Do not throw CRITICAL if the file is missing',
+    :boolean => true,
+    :default => false
+
+  option :debug,
+    :short => '-d',
+    :long => '--debug',
+    :description => 'Output list of included filesystems',
+    :boolean => true,
+    :default => false
+
+  def stat_file
+    if File.exist? config[:file]
+      stat = File.stat(config[:file])
+      $stdout.puts stat.inspect if config[:debug] == true
+      @file_size = stat.size
+    else
+      if config[:ignore_missing] == true
+        ok "#{config[:file]} does not exist (--ignore-missing was set)"
+      else
+        critical "#{config[:file]} does not exist"
+      end
+    end
+  end
+
+  def compare_size
+    if @file_size >= config[:crit].to_i
+      critical "#{config[:file]} is greater than #{format_bytes(config[:crit])} bytes! [actual size: #{format_bytes(@file_size)} bytes]"
+    elsif @file_size >= config[:warn]
+      warning "#{config[:file]} is greater than #{format_bytes(config[:warn])} bytes! [actual size: #{format_bytes(@file_size)} bytes]"
+    else
+      ok "#{config[:file]} is within size limit"
+    end
+  end
+
+  def run
+    stat_file
+    compare_size
+  end
+
+  def format_bytes(number)
+    number.to_s.reverse.gsub(/(\d{3})(?=\d)/, '\\1,').reverse
+  end
+end

--- a/plugins/files/check-file-size.rb
+++ b/plugins/files/check-file-size.rb
@@ -34,38 +34,38 @@ class CheckFileSize < Sensu::Plugin::Check::CLI
   attr_accessor :file_size
 
   option :file,
-    :description => 'file to stat (full path)',
-    :short => '-f',
-    :long => '--file FILENAME',
-    :required => true
+         description: 'file to stat (full path)',
+         short: '-f',
+         long: '--file FILENAME',
+         required: true
 
   option :warn,
-    :description => 'The size (in bytes) of the file where WARNING is raised',
-    :short => '-w SIZE',
-    :long => '--warn SIZE',
-    :proc => proc(&:to_i),
-    :default => 2_000_000
+         description: 'The size (in bytes) of the file where WARNING is raised',
+         short: '-w SIZE',
+         long: '--warn SIZE',
+         proc: proc(&:to_i),
+         default: 2_000_000
 
   option :crit,
-    :description => 'The size (in bytes) of the file where CRITICAL is raised',
-    :short => '-c SIZE',
-    :long => '--critical SIZE',
-    :proc => proc(&:to_i),
-    :default => 3_000_000
+         description: 'The size (in bytes) of the file where CRITICAL is raised',
+         short: '-c SIZE',
+         long: '--critical SIZE',
+         proc: proc(&:to_i),
+         default: 3_000_000
 
   option :ignore_missing,
-    :short => '-i',
-    :long => '--ignore-missing',
-    :description => 'Do not throw CRITICAL if the file is missing',
-    :boolean => true,
-    :default => false
+         short: '-i',
+         long: '--ignore-missing',
+         description: 'Do not throw CRITICAL if the file is missing',
+         boolean: true,
+         default: false
 
   option :debug,
-    :short => '-d',
-    :long => '--debug',
-    :description => 'Output list of included filesystems',
-    :boolean => true,
-    :default => false
+         short: '-d',
+         long: '--debug',
+         description: 'Output list of included filesystems',
+         boolean: true,
+         default: false
 
   def stat_file
     if File.exist? config[:file]

--- a/spec/plugins/files/check-file-size_spec.rb
+++ b/spec/plugins/files/check-file-size_spec.rb
@@ -27,31 +27,27 @@
 require_relative '../../../plugins/files/check-file-size'
 require_relative '../../../spec_helper'
 
-describe CheckFileSize, 'run' do
+describe CheckFileSize do
 
-  check_file_size = nil
-
-  before(:each) do
-    check_file_size = CheckFileSize.new
+  it 'will fail with no parameters' do
   end
 
-  describe 'using no parameters' do
-    it 'will fail'
+  it 'returns CRITICAL if file is missing' do
   end
 
-  describe '#ignore-missing' do
-    it 'returns CRITICAL if file is missing'
-    it 'returns OK if file is missing and --ignore-missing is used'
+  it 'returns OK if file is missing and --ignore-missing is used' do
   end
 
-  describe '#warning' do
-    it 'returns OK if file size is under --warn value'
-    it 'returns WARNING if file size is over --warn value'
+  it 'returns OK if file size is under --warn value' do
   end
 
-  describe '#critical' do
-    it 'returns OK if file size is under --critical value'
-    it 'returns CRITICAL if file size is over --critical value'
+  it 'returns WARNING if file size is over --warn value' do
+  end
+
+  it 'returns OK if file size is under --critical value' do
+  end
+
+  it 'returns CRITICAL if file size is over --critical value' do
   end
 
 end

--- a/spec/plugins/files/check-file-size_spec.rb
+++ b/spec/plugins/files/check-file-size_spec.rb
@@ -1,0 +1,57 @@
+#! /usr/bin/env ruby
+#
+#   check-file-size_spec.rb
+#
+# DESCRIPTION:
+#   Run rspec tests against check-file-size.rb Sensu check
+#
+# OUTPUT:
+#   rspec output
+#
+# PLATFORMS:
+#   Linux
+#
+# DEPENDENCIES:
+#   rspec
+#
+# USAGE:
+#
+# NOTES:
+#
+# LICENSE:
+#   Copyright 2015 Jayson Sperling <jayson.sperling@sendgrid.com>
+#   Released under the same terms as Sensu (the MIT license); see LICENSE
+#   for details.
+#
+
+require_relative '../../../plugins/files/check-file-size'
+require_relative '../../../spec_helper'
+
+describe CheckFileSize, 'run' do
+
+  check_file_size = nil
+
+  before(:each) do
+    check_file_size = CheckFileSize.new
+  end
+
+  describe 'using no parameters' do
+    it 'will fail'
+  end
+
+  describe '#ignore-missing' do
+    it 'returns CRITICAL if file is missing'
+    it 'returns OK if file is missing and --ignore-missing is used'
+  end
+
+  describe '#warning' do
+    it 'returns OK if file size is under --warn value'
+    it 'returns WARNING if file size is over --warn value'
+  end
+
+  describe '#critical' do
+    it 'returns OK if file size is under --critical value'
+    it 'returns CRITICAL if file size is over --critical value'
+  end
+
+end


### PR DESCRIPTION
Add a check that allows Sensu to check for a file size (warn and critical sizes). Also allows to not go critical if the file just doesn't exist.

USAGE:
check-file-size.rb -f <file> [optional parameters]
    -c, --critical SIZE              The size (in bytes) of the file where CRITICAL is raised, default of 3,000,000
    -d, --debug                      Output list of included filesystems
    -f, --file FILENAME              file to stat (full path) (required)
    -i, --ignore-missing             Do not throw CRITICAL if the file is missing
    -w, --warn SIZE                  The size (in bytes) of the file where WARNING is raised, default of 2,000,000

EXAMPLES:
WARN if file is over 15,000 bytes:
```
check-file-size.rb -f ./test-file -w 15000
CheckFileSize WARNING: ./test-file is greater than 15,000 bytes! [actual size: 16,794 bytes]
```

CRITICAL if file size is over 16,000 bytes:
```
check-file-size.rb -f ./test-file -c 16000
CheckFileSize CRITICAL: ./test-file is greater than 16,000 bytes! [actual size: 16,794 bytes]
```

CRITICAL if file size is over 5,000 bytes but ignore if missing:
```
check-file-size.rb -f ./missing-test-file -c 1500 --ignore-missing
CheckFileSize OK: ./missing-test-file does not exist (--ignore-missing was set)
```
