### PR TITLE
Added user-not flag

### DIFF
--- a/plugins/processes/check-procs.rb
+++ b/plugins/processes/check-procs.rb
@@ -121,6 +121,12 @@ class CheckProcs < Sensu::Plugin::Check::CLI
          description: 'Trigger on a specific user',
          proc: proc { |a| a.split(',') }
 
+  option :usernot,
+         short: '-U USER',
+         long: '--user-not USER',
+         description: 'Trigger if not owned a specific user',
+         proc: proc { |a| a.split(',') }
+
   option :esec_over,
          short: '-e SECONDS',
          long: '--esec-over SECONDS',
@@ -216,11 +222,13 @@ class CheckProcs < Sensu::Plugin::Check::CLI
     procs.reject! { |p| cputime_to_csec(p[:time]) <= config[:cpu_over] } if config[:cpu_over]
     procs.reject! { |p| !config[:state].include?(p[:state]) } if config[:state]
     procs.reject! { |p| !config[:user].include?(p[:user]) } if config[:user]
+    procs.reject! { |p| config[:usernot].include?(p[:user]) } if config[:usernot]
 
     msg = "Found #{procs.size} matching processes"
     msg += "; cmd /#{config[:cmd_pat]}/" if config[:cmd_pat]
     msg += "; state #{config[:state].join(',')}" if config[:state]
     msg += "; user #{config[:user].join(',')}" if config[:user]
+    msg += "; not user #{config[:usernot].join(',')}" if config[:usernot]
     msg += "; vsz < #{config[:vsz]}" if config[:vsz]
     msg += "; rss < #{config[:rss]}" if config[:rss]
     msg += "; pcpu < #{config[:pcpu]}" if config[:pcpu]


### PR DESCRIPTION
Check for processes NOT owned by user
e.g.
```
# /etc/sensu/plugins/processes/check-procs.rb -p "/var/lib/dmcm/etc" -U root -C 0
CheckProcs OK: Found 6 matching processes; cmd //var/lib/dmcm/etc/; not user root

# ps axwwo user,command | grep '/var/lib/dmcm/etc'
dmcmsvc  /usr/lib/jvm/java-7
-Dfile.encoding=UTF-8 -Duser.timezone=UTC -Djava.net.preferIPv4Stack=true ...  -Ddcm.configurationSource.localURL=file:///var/lib/dmcm/etc/dcm-config-local.yaml
...[ 6 more similar processes ] ...
```