### PR TITLE
Convert timeout string to integer

### DIFF
--- a/plugins/pingdom/check-pingdom-credits.rb
+++ b/plugins/pingdom/check-pingdom-credits.rb
@@ -69,7 +69,8 @@ class CheckPingdomCredits < Sensu::Plugin::Check::CLI
 
   option :timeout,
          short: '-t SECS',
-         default: 10
+         default: 10,
+         proc: proc(&:to_i)
 
   def run
     check_sms!


### PR DESCRIPTION
check-pingdom-credits.rb fails with "CheckPingdomCredits CRITICAL: Check failed to run: can't convert String into time interval” when timeout option is used.  This change enables the use of the timeout option to change the default timeout.