### PR TITLE
Supported seeking over log lines which contain multibyte characters.

### DIFF
--- a/plugins/logging/check-log.rb
+++ b/plugins/logging/check-log.rb
@@ -181,7 +181,7 @@ class CheckLog < Sensu::Plugin::Check::CLI
     @log.seek(@bytes_to_skip, File::SEEK_SET) if @bytes_to_skip > 0
     # #YELLOW
     @log.each_line do |line| # rubocop:disable Style/Next
-      bytes_read += line.size
+      bytes_read += line.bytesize
       if config[:case_insensitive]
         m = line.downcase.match(config[:pattern].downcase) unless line.match(config[:exclude])
       else


### PR DESCRIPTION
If a log has multibyte, check-log.rb unexpectedly behaves because String#size doesn't tell byte size but the number of characters.
However, ruby 1.8.6 or lower doesn't seem to support bytesize method. I wonder whether I should support lower version.

■Before Fixing
※The string "ＴＥＳＴ" is multibyte alphabets
```
% echo 0 > /var/cache/check-log/default/tmp/test.log
% echo "ＴＥＳＴ" > /tmp/test.log
% ./check-log.rb -f /tmp/test.log -q 'test' -e 'UTF-8'
CheckLog OK: 0 warnings, 0 criticals for pattern test.
% cat /var/cache/check-log/default/tmp/test.log
5
% echo "test" >> /tmp/test.log
% ./check-log.rb -f /tmp/test.log -q 'test' -e 'UTF-8'
Check failed to run: invalid byte sequence in UTF-8, ["./check-log.rb:188:in `match'", "./check-log.rb:188:in `match'", "./check-log.rb:188:in `block in search_log'", "./check-log.rb:183:in `each_line'", "./check-log.rb:183:in `search_log'", "./check-log.rb:135:in `block in run'", "./check-log.rb:129:in `each'", "./check-log.rb:129:in `run'", "/usr/local/ruby-2.1.6/lib/ruby/gems/2.1.0/gems/sensu-plugin-1.1.0/lib/sensu-plugin/cli.rb:56:in `block in <class:CLI>'"]
```

■After Fixing
※The string "ＴＥＳＴ" is multibyte alphabets
```
% echo 0 > /var/cache/check-log/default/tmp/test.log
% echo "ＴＥＳＴ" > /tmp/test.log
% ./check-log.rb -f /tmp/test.log -q 'test' -e 'UTF-8'
CheckLog OK: 0 warnings, 0 criticals for pattern test.
% cat /var/cache/check-log/default/tmp/test.log
13
% echo "test" >> /tmp/test.log
% ./check-log.rb -f /tmp/test.log -q 'test' -e 'UTF-8'
CheckLog CRITICAL: 0 warnings, 1 criticals for pattern test.
% cat /var/cache/check-log/default/tmp/test.log
18
```