### PR TITLE
rabbitmq-queue-metrics.rb: Fix drain_time = 0 check

### DIFF
--- a/plugins/rabbitmq/rabbitmq-queue-metrics.rb
+++ b/plugins/rabbitmq/rabbitmq-queue-metrics.rb
@@ -92,7 +92,7 @@ class RabbitMQMetrics < Sensu::Plugin::Metric::CLI::Graphite
 
       # calculate and output time till the queue is drained in drain metrics
       drain_time = queue['messages'] / queue['backing_queue_status']['avg_egress_rate']
-      drain_time = 0 if drain_time.nan? # 0 rate with 0 messages is 0 time to drain
+      drain_time = 0 unless drain_time.finite? # 0 rate with 0 messages is 0 time to drain
       output([config[:scheme], queue['name'], 'drain_time'].join('.'), drain_time.to_i, timestamp)
 
       %w(messages consumers).each do |metric|


### PR DESCRIPTION
In https://github.com/sensu/sensu-community-plugins/blob/f807971cee35bfc59f2217073f1cca25f7236e2e/plugins/rabbitmq/rabbitmq-queue-metrics.rb#L95 `drain_time` is set to 0 in case we divide by 0 in the previous line. Only `nan?` is used rather that `infinite?`, division by 0 yields `Infinity` which is a "number" so `nan?` is false. Using `unless finite?` fixes this.