### PR TITLE
add TIMEOUT option so token timeout value is not hardcoded

### DIFF
--- a/plugins/openstack/keystone/check_keystone-api.sh
+++ b/plugins/openstack/keystone/check_keystone-api.sh
@@ -38,9 +38,10 @@ usage ()
     echo " -H <Auth URL>    URL for obtaining an auth token"
     echo " -U <username>    Username to use to get an auth token"
     echo " -P <password>    Password to use ro get an auth token"
+    echo " -T <seconds>     Timeout after integer <seconds>"
 }
 
-while getopts 'h:H:U:T:P:' OPTION
+while getopts 'h:H:U:P:T:' OPTION
 do
     case $OPTION in
         h)
@@ -56,6 +57,9 @@ do
         P)
             export OS_PASSWORD=$OPTARG
             ;;
+        T)
+            export TIMEOUT=$OPTARG
+            ;;
         *)
             usage
             exit 1
@@ -69,9 +73,14 @@ then
     exit $STATE_UNKNOWN
 fi
 
-START=`date +%s`
+if [ ! -z "${TIMEOUT//[0-9]}" ]; then
+    echo "TIMEOUT value is not an integer"
+    exit $STATE_UNKNOWN
+fi
+
+START=$(date +%s)
 TOKEN=$(curl -d '{"auth":{"passwordCredentials":{"username": "'$OS_USERNAME'", "password": "'$OS_PASSWORD'"}}}' -H "Content-type: application/json" ${OS_AUTH_URL}:5000/v2.0/tokens/ 2>&1 | grep token|awk '{print $8}'|grep -o '".*"' | sed -n 's/.*"\([^"]*\)".*/\1/p')
-END=`date +%s`
+END=$(date +%s)
 
 TIME=$((END-START))
 
@@ -79,11 +88,11 @@ if [ -z "$TOKEN" ]; then
     echo "Unable to get a token"
     exit $STATE_CRITICAL
 else
-    if [ $TIME -gt 10 ]; then
-        echo "Get a token after 10 seconds, it's too long."
+    if [ $TIME -gt $TIMEOUT ]; then
+        echo "Got a token after $TIMEOUT seconds. That is too long."
         exit $STATE_WARNING
     else
-        echo "Got a token, Keystone API is working."
+        echo "Got a token. Keystone API is working."
         exit $STATE_OK
     fi
 fi


### PR DESCRIPTION
In Enterprise production environments, having this check fail after 10 seconds (as was hard-coded into script) can lead to an unnecessary flood of alerts. Failing to get a token in less than 10 seconds does not necessarily indicate an issue. I have tested increasing the timeout to 15 seconds, and that seems to be a good value for our environment. Whatever the correct value will be for a given environment, it is much better to pass the value as an option rather than having it hard-coded into the script.